### PR TITLE
Topologies shouldnt reinitialise their entities when they are cloned.

### DIFF
--- a/src/main/java/net/sourceforge/cilib/entity/topologies/GBestTopology.java
+++ b/src/main/java/net/sourceforge/cilib/entity/topologies/GBestTopology.java
@@ -60,7 +60,6 @@ public class GBestTopology<E extends Entity> extends AbstractTopology<E> {
     public GBestTopology(GBestTopology<E> copy) {
         this.entities = new LinkedList<E>();
         for (E entity : copy.entities) {
-            entity.reinitialise();
             this.entities.add((E) entity.getClone());
         }
     }


### PR DESCRIPTION
Removed the reinitialising line.
