### PR TITLE
Probability distributions now use control parameters.

### DIFF
--- a/src/main/java/net/sourceforge/cilib/functions/continuous/dynamic/GeneralizedMovingPeaks.java
+++ b/src/main/java/net/sourceforge/cilib/functions/continuous/dynamic/GeneralizedMovingPeaks.java
@@ -354,6 +354,6 @@ public class GeneralizedMovingPeaks implements ContinuousFunction, DynamicFuncti
     }
 
     public void setSeed(long seed) {
-        ((UniformDistribution)uniform).setProvider(new MersenneTwister(seed));
+        uniform.setRandomProvider(new MersenneTwister(seed));
     }
 }

--- a/src/main/java/net/sourceforge/cilib/math/random/CauchyDistribution.java
+++ b/src/main/java/net/sourceforge/cilib/math/random/CauchyDistribution.java
@@ -22,6 +22,8 @@
 package net.sourceforge.cilib.math.random;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import net.sourceforge.cilib.controlparameter.ConstantControlParameter;
+import net.sourceforge.cilib.controlparameter.ControlParameter;
 import net.sourceforge.cilib.math.random.generator.MersenneTwister;
 import net.sourceforge.cilib.math.random.generator.RandomProvider;
 
@@ -31,16 +33,22 @@ import net.sourceforge.cilib.math.random.generator.RandomProvider;
 public class CauchyDistribution implements ProbabilityDistributionFuction {
 
     private RandomProvider provider;
+    private ControlParameter location;
+    private ControlParameter scale;
 
     /**
      * Default Constructor
      */
     public CauchyDistribution() {
         this.provider = new MersenneTwister();
+        this.location = ConstantControlParameter.of(0.0);
+        this.scale = ConstantControlParameter.of(1.0);
     }
 
     public CauchyDistribution(long seed) {
         this.provider = new MersenneTwister(seed);
+        this.location = ConstantControlParameter.of(0.0);
+        this.scale = ConstantControlParameter.of(1.0);
     }
 
     /**
@@ -50,7 +58,7 @@ public class CauchyDistribution implements ProbabilityDistributionFuction {
      */
     @Override
     public double getRandomNumber() {
-        return getRandomNumber(0.0, 1.0);
+        return getRandomNumber(location.getParameter(), scale.getParameter());
     }
 
     /**
@@ -72,19 +80,29 @@ public class CauchyDistribution implements ProbabilityDistributionFuction {
         return locationScale[0] + locationScale[1] * Math.tan(Math.PI * (x - 0.5));
     }
 
-    public RandomProvider getProvider() {
-        return provider;
-    }
-
-    public void setProvider(RandomProvider provider) {
-        this.provider = provider;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public RandomProvider getRandomProvider() {
         return provider;
+    }
+
+    @Override
+    public void setRandomProvider(RandomProvider provider) {
+        this.provider = provider;
+    }
+
+    public void setScale(ControlParameter scale) {
+        this.scale = scale;
+    }
+
+    public ControlParameter getScale() {
+        return scale;
+    }
+
+    public void setLocation(ControlParameter location) {
+        this.location = location;
+    }
+
+    public ControlParameter getLocation() {
+        return location;
     }
 }

--- a/src/main/java/net/sourceforge/cilib/math/random/ExponentialDistribution.java
+++ b/src/main/java/net/sourceforge/cilib/math/random/ExponentialDistribution.java
@@ -22,6 +22,8 @@
 package net.sourceforge.cilib.math.random;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import net.sourceforge.cilib.controlparameter.ConstantControlParameter;
+import net.sourceforge.cilib.controlparameter.ControlParameter;
 import net.sourceforge.cilib.math.random.generator.MersenneTwister;
 import net.sourceforge.cilib.math.random.generator.RandomProvider;
 
@@ -31,13 +33,16 @@ import net.sourceforge.cilib.math.random.generator.RandomProvider;
 public class ExponentialDistribution implements ProbabilityDistributionFuction {
 
     private RandomProvider provider;
+    private ControlParameter rate;
 
     public ExponentialDistribution() {
         provider = new MersenneTwister();
+        rate = ConstantControlParameter.of(1.0);
     }
 
     public ExponentialDistribution(long seed) {
         provider = new MersenneTwister(seed);
+        rate = ConstantControlParameter.of(1.0);
     }
 
     /**
@@ -46,7 +51,7 @@ public class ExponentialDistribution implements ProbabilityDistributionFuction {
      */
     @Override
     public double getRandomNumber() {
-        return getRandomNumber(1);
+        return getRandomNumber(rate.getParameter());
     }
 
     /**
@@ -65,11 +70,23 @@ public class ExponentialDistribution implements ProbabilityDistributionFuction {
         return -Math.log(1 - r) / rate[0];
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public RandomProvider getRandomProvider() {
         return provider;
     }
+
+    @Override
+    public void setRandomProvider(RandomProvider provider) {
+        this.provider = provider;
+    }
+
+    public ControlParameter getRate() {
+        return rate;
+    }
+
+    public void setRate(ControlParameter rate) {
+        this.rate = rate;
+    }
+
+
 }

--- a/src/main/java/net/sourceforge/cilib/math/random/GammaDistribution.java
+++ b/src/main/java/net/sourceforge/cilib/math/random/GammaDistribution.java
@@ -22,6 +22,8 @@
 package net.sourceforge.cilib.math.random;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import net.sourceforge.cilib.controlparameter.ConstantControlParameter;
+import net.sourceforge.cilib.controlparameter.ControlParameter;
 import net.sourceforge.cilib.math.random.generator.MersenneTwister;
 import net.sourceforge.cilib.math.random.generator.RandomProvider;
 
@@ -31,13 +33,19 @@ import net.sourceforge.cilib.math.random.generator.RandomProvider;
 public class GammaDistribution implements ProbabilityDistributionFuction {
 
     private RandomProvider provider;
+    private ControlParameter shape;
+    private ControlParameter scale;
 
     public GammaDistribution() {
         provider = new MersenneTwister();
+        shape = ConstantControlParameter.of(2.0);
+        scale = ConstantControlParameter.of(2.0);
     }
 
     public GammaDistribution(long seed) {
         provider = new MersenneTwister(seed);
+        shape = ConstantControlParameter.of(2.0);
+        scale = ConstantControlParameter.of(2.0);
     }
 
     /**
@@ -46,7 +54,7 @@ public class GammaDistribution implements ProbabilityDistributionFuction {
      */
     @Override
     public double getRandomNumber() {
-        return getRandomNumber(2, 2.0);
+        return getRandomNumber(shape.getParameter(), scale.getParameter());
     }
 
     /**
@@ -80,9 +88,27 @@ public class GammaDistribution implements ProbabilityDistributionFuction {
         return sum;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    public void setShape(ControlParameter shape) {
+        this.shape = shape;
+    }
+
+    public ControlParameter getShape() {
+        return shape;
+    }
+
+    public void setScale(ControlParameter scale) {
+        this.scale = scale;
+    }
+
+    public ControlParameter getScale() {
+        return scale;
+    }
+
+    @Override
+    public void setRandomProvider(RandomProvider provider) {
+        this.provider = provider;
+    }
+
     @Override
     public RandomProvider getRandomProvider() {
         return provider;

--- a/src/main/java/net/sourceforge/cilib/math/random/GaussianDistribution.java
+++ b/src/main/java/net/sourceforge/cilib/math/random/GaussianDistribution.java
@@ -22,6 +22,8 @@
 package net.sourceforge.cilib.math.random;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import net.sourceforge.cilib.controlparameter.ConstantControlParameter;
+import net.sourceforge.cilib.controlparameter.ControlParameter;
 import net.sourceforge.cilib.math.random.generator.MersenneTwister;
 import net.sourceforge.cilib.math.random.generator.RandomProvider;
 
@@ -30,16 +32,22 @@ import net.sourceforge.cilib.math.random.generator.RandomProvider;
 public class GaussianDistribution implements ProbabilityDistributionFuction {
 
     private RandomProvider provider;
+    private ControlParameter mean;
+    private ControlParameter deviation;
 
     /**
      * Default constructor.
      */
     public GaussianDistribution() {
         provider = new MersenneTwister();
+        mean = ConstantControlParameter.of(0.0);
+        deviation = ConstantControlParameter.of(1.0);
     }
 
     public GaussianDistribution(long seed) {
         provider = new MersenneTwister(seed);
+        mean = ConstantControlParameter.of(0.0);
+        deviation = ConstantControlParameter.of(1.0);
     }
 
     /**
@@ -48,7 +56,7 @@ public class GaussianDistribution implements ProbabilityDistributionFuction {
      */
     @Override
     public double getRandomNumber() {
-        return getRandomNumber(0.0, 1.0);
+        return getRandomNumber(mean.getParameter(), deviation.getParameter());
     }
 
     /**
@@ -111,16 +119,29 @@ public class GaussianDistribution implements ProbabilityDistributionFuction {
         return (locationScale[0] + locationScale[1] * v / u);
     }
 
-    public RandomProvider getProvider() {
+    @Override
+    public RandomProvider getRandomProvider() {
         return provider;
     }
 
-    public void setProvider(RandomProvider provider) {
+    @Override
+    public void setRandomProvider(RandomProvider provider) {
         this.provider = provider;
     }
 
-    @Override
-    public RandomProvider getRandomProvider() {
-        return this.provider;
+    public void setDeviation(ControlParameter deviation) {
+        this.deviation = deviation;
+    }
+
+    public ControlParameter getDeviation() {
+        return deviation;
+    }
+
+    public void setMean(ControlParameter mean) {
+        this.mean = mean;
+    }
+
+    public ControlParameter getMean() {
+        return mean;
     }
 }

--- a/src/main/java/net/sourceforge/cilib/math/random/LaplaceDistribution.java
+++ b/src/main/java/net/sourceforge/cilib/math/random/LaplaceDistribution.java
@@ -22,6 +22,8 @@
 package net.sourceforge.cilib.math.random;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import net.sourceforge.cilib.controlparameter.ConstantControlParameter;
+import net.sourceforge.cilib.controlparameter.ControlParameter;
 import net.sourceforge.cilib.math.random.generator.MersenneTwister;
 import net.sourceforge.cilib.math.random.generator.RandomProvider;
 
@@ -31,13 +33,19 @@ import net.sourceforge.cilib.math.random.generator.RandomProvider;
 public class LaplaceDistribution implements ProbabilityDistributionFuction {
 
     private RandomProvider provider;
+    private ControlParameter location;
+    private ControlParameter scale;
 
     public LaplaceDistribution() {
         provider = new MersenneTwister();
+        location = ConstantControlParameter.of(0.0);
+        scale = ConstantControlParameter.of(1.0);
     }
 
     public LaplaceDistribution(long seed) {
         provider = new MersenneTwister(seed);
+        location = ConstantControlParameter.of(0.0);
+        scale = ConstantControlParameter.of(1.0);
     }
 
     /**
@@ -46,7 +54,7 @@ public class LaplaceDistribution implements ProbabilityDistributionFuction {
      */
     @Override
     public double getRandomNumber() {
-        return getRandomNumber(0, 1);
+        return getRandomNumber(location.getParameter(), scale.getParameter());
     }
 
     /**
@@ -67,11 +75,30 @@ public class LaplaceDistribution implements ProbabilityDistributionFuction {
         return parameters[0] - parameters[1] * (Math.log(1 - 2 * Math.abs(r))) * Math.signum(r);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    public void setScale(ControlParameter scale) {
+        this.scale = scale;
+    }
+
+    public ControlParameter getScale() {
+        return scale;
+    }
+
+    @Override
+    public void setRandomProvider(RandomProvider provider) {
+        this.provider = provider;
+    }
+
     @Override
     public RandomProvider getRandomProvider() {
         return provider;
     }
+
+    public void setLocation(ControlParameter location) {
+        this.location = location;
+    }
+
+    public ControlParameter getLocation() {
+        return location;
+    }
+
 }

--- a/src/main/java/net/sourceforge/cilib/math/random/ProbabilityDistributionFuction.java
+++ b/src/main/java/net/sourceforge/cilib/math/random/ProbabilityDistributionFuction.java
@@ -49,13 +49,7 @@ public interface ProbabilityDistributionFuction {
      */
     double getRandomNumber(double... parameters);
 
-    /**
-     * Obtain the internal Pseudo-random number generator.
-     *
-     * <p><b>IMPORTANT:</b> this method is highly suspect... It should probably
-     * not exist and the RandomProvider should be either used otherwise and
-     * not be obtained by "reaching" into this object.
-     * @return
-     */
     RandomProvider getRandomProvider();
+
+    void setRandomProvider(RandomProvider provider);
 }

--- a/src/main/java/net/sourceforge/cilib/math/random/UniformDistribution.java
+++ b/src/main/java/net/sourceforge/cilib/math/random/UniformDistribution.java
@@ -22,6 +22,8 @@
 package net.sourceforge.cilib.math.random;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import net.sourceforge.cilib.controlparameter.ConstantControlParameter;
+import net.sourceforge.cilib.controlparameter.ControlParameter;
 import net.sourceforge.cilib.math.random.generator.MersenneTwister;
 import net.sourceforge.cilib.math.random.generator.RandomProvider;
 
@@ -31,16 +33,22 @@ import net.sourceforge.cilib.math.random.generator.RandomProvider;
 public class UniformDistribution implements ProbabilityDistributionFuction {
 
     private RandomProvider provider;
+    private ControlParameter lowerBound;
+    private ControlParameter upperBound;
 
     /**
      * Default Constructor
      */
     public UniformDistribution() {
         this.provider = new MersenneTwister();
+        lowerBound = ConstantControlParameter.of(0.0);
+        upperBound = ConstantControlParameter.of(1.0);
     }
 
     public UniformDistribution(long seed) {
         this.provider = new MersenneTwister(seed);
+        lowerBound = ConstantControlParameter.of(0.0);
+        upperBound = ConstantControlParameter.of(1.0);
     }
 
     /**
@@ -50,7 +58,7 @@ public class UniformDistribution implements ProbabilityDistributionFuction {
      */
     @Override
     public double getRandomNumber() {
-        return getRandomNumber(0.0, 1.0);
+        return getRandomNumber(lowerBound.getParameter(), upperBound.getParameter());
     }
 
     /**
@@ -73,19 +81,13 @@ public class UniformDistribution implements ProbabilityDistributionFuction {
         return ((bounds[1] - bounds[0]) * r + bounds[0]);
     }
 
-    public RandomProvider getProvider() {
+    @Override
+    public RandomProvider getRandomProvider() {
         return provider;
     }
 
-    public void setProvider(RandomProvider provider) {
-        this.provider = provider;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public RandomProvider getRandomProvider() {
-        return this.provider;
+    public void setRandomProvider(RandomProvider provider) {
+        this.provider = provider;
     }
 }


### PR DESCRIPTION
Added control parameters to probability distributions. Any call to getRandomNumber results in the control parameters being used but I left the getRandomParameters(double... parameters) method intact because 
a) some classes change the parameters themselves
b) some classes have their own control parameters which affect the random numbers (it makes more sense for the user to set the parameters in those classes, being related and all, than to let the distribution control it.)

These changes also allow the parameters to be set in XML.
