### PR TITLE
The DimensionBoundViolationsPerParticle was incorrectly implemented.

### DIFF
--- a/library/src/main/java/net/sourceforge/cilib/measurement/single/DimensionBoundViolationsPerParticle.java
+++ b/library/src/main/java/net/sourceforge/cilib/measurement/single/DimensionBoundViolationsPerParticle.java
@@ -90,9 +90,9 @@ public class DimensionBoundViolationsPerParticle implements Measurement<Real> {
                     numberOfViolations++;
                 }
             }
-            sumOfAverageViolations += (double) numberOfViolations / (double) dimension;
+            sumOfAverageViolations += numberOfViolations;
         }
 
-        return Real.valueOf(sumOfAverageViolations / (double) populationSize * (double) dimension);
+        return Real.valueOf(sumOfAverageViolations / (double) populationSize);
     }
 }


### PR DESCRIPTION
It is now corrected.

Signed-off-by: Andries Engelbrecht engel@cs.up.ac.za
