### PR TITLE
Refactored the getSolutions method in PSO as well as related topology im...

### DIFF
--- a/library/src/main/java/net/sourceforge/cilib/entity/Topologies.java
+++ b/library/src/main/java/net/sourceforge/cilib/entity/Topologies.java
@@ -56,6 +56,24 @@ public final class Topologies {
     }
 
     /**
+     * Gather the best entity of each neighbourhood (in this {@link Topology}) in a
+     * {@link Set} (duplicates are not allowed) and return them. A single {@link Entity} may
+     * dominate in more than one neighbourhood, but we just want unique entities.
+     */
+    public static <T extends Entity> Set<T> getNicheBestEntities(List<T> p, Neighbourhood<E> neighbourhood, Comparator<? super T> c) {
+        Set<E> nBests = new LinkedHashSet<E>(p.length());
+
+        for (E e : p) {
+            E best = getBestEntity(p.niche(e), c);
+            if (best != null) {
+                nBests.add(best);
+            }
+        }
+
+        return nBests;
+    }
+
+    /**
      * Returns the current best entity from a given topology based on the current
      * fitness of the entities.
      */

--- a/library/src/main/java/net/sourceforge/cilib/pso/PSO.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/PSO.java
@@ -120,7 +120,11 @@ public class PSO extends SinglePopulationBasedAlgorithm<Particle> {
     @Override
     public List<OptimisationSolution> getSolutions() {
         List<OptimisationSolution> solutions = Lists.newLinkedList();
+/*<<<<<<< HEAD
         for (Particle e : Topologies.getNeighbourhoodBestEntities(topology, neighbourhood, new SocialBestFitnessComparator<Particle>())) {
+=======*/
+        for (Particle e : Topologies.getNicheBestEntities(topology, new SocialBestFitnessComparator<Particle>())) {
+//>>>>>>> Refactored the getSolutions method in PSO as well as related topology implementations.
             solutions.add(new OptimisationSolution(e.getBestPosition(), e.getBestFitness()));
         }
         return solutions;

--- a/library/src/test/java/net/sourceforge/cilib/entity/topologies/SpeciationTopologyTest.java
+++ b/library/src/test/java/net/sourceforge/cilib/entity/topologies/SpeciationTopologyTest.java
@@ -111,10 +111,68 @@ public class SpeciationTopologyTest {
         assertEquals(n9.index(2).getFitness().getValue(), 7.0, 0.0);
 
         //10
+//<<<<<<< HEAD
         List<Particle> n10 = s.f(particles, p10);
         assertEquals(n10.index(0).getFitness().getValue(), 5.0, 0.0);
         assertEquals(n10.index(1).getFitness().getValue(), 6.0, 0.0);
         assertEquals(n10.index(2).getFitness().getValue(), 7.0, 0.0);
+/*=======
+        c = i.next();
+        assertEquals(c.getFitness().getValue(), 7.0, 0.0);
+        n = s.neighbourhood(c);
+        nIter = n.iterator();
+        assertEquals(nIter.next().getFitness().getValue(), 5.0, 0.0);
+        assertEquals(nIter.next().getFitness().getValue(), 6.0, 0.0);
+        assertEquals(nIter.next().getFitness().getValue(), 7.0, 0.0);
+        assertFalse(nIter.hasNext());
+    }
+
+    @Test
+    public void testNiche() {
+        Particle p1 = createParticle(new MinimisationFitness(9.0), Vector.of(1.0)); //0
+        Particle p2 = createParticle(new MinimisationFitness(1.0), Vector.of(2.0)); //1
+        Particle p3 = createParticle(new MinimisationFitness(8.0), Vector.of(3.0)); //2
+        Particle p4 = createParticle(new MinimisationFitness(3.0), Vector.of(4.0)); //3
+        Particle p5 = createParticle(new MinimisationFitness(4.0), Vector.of(5.0)); //4
+        Particle p6 = createParticle(new MinimisationFitness(0.0), Vector.of(6.0)); //5
+        Particle p7 = createParticle(new MinimisationFitness(2.0), Vector.of(7.0)); //6
+        Particle p8 = createParticle(new MinimisationFitness(6.0), Vector.of(8.0)); //7
+        Particle p9 = createParticle(new MinimisationFitness(5.0), Vector.of(9.0)); //8
+        Particle p10 = createParticle(new MinimisationFitness(7.0), Vector.of(10.0)); //9
+
+        SpeciationTopology<Particle> s = new SpeciationTopology<Particle>();
+        s.setNeighbourhoodSize(ConstantControlParameter.of(3));
+        s.setRadius(ConstantControlParameter.of(2.1));
+        s.addAll(Arrays.asList(p3,p2,p1,p4,p5,p6,p7,p8,p9,p10));
+
+        for (Particle c : s) {
+            Collection<Particle> neigh = s.neighbourhood(c);
+            Collection<Particle> niche = s.niche(c);
+
+            assert(neigh.equals(niche));
+        }
+    }
+
+    @Test
+    public void testInRadius() {
+        DistanceMeasure distance = new EuclideanDistanceMeasure();
+        ControlParameter radius = ConstantControlParameter.of(10.0);
+
+        Particle p1 = new StandardParticle();
+        p1.setCandidateSolution(Vector.of(10.0, 10.0));
+        Particle p2 = new StandardParticle();
+        p2.setCandidateSolution(Vector.of(5.0, 5.0));
+        Particle other = new StandardParticle();
+        other.setCandidateSolution(Vector.of(0.0, 0.0));
+
+        assertFalse(SpeciationTopology.inRadius(distance, radius, other).f(P.p(p1, 1)));
+        assertTrue(SpeciationTopology.inRadius(distance, radius, other).f(P.p(p2, 1)));
+
+        List<P2<Particle, Integer>> top = List.<Particle>list(p1, p2, other)
+                .zipIndex()
+                .filter(SpeciationTopology.inRadius(distance, radius, other));
+        assertEquals(top.length(), 2);
+>>>>>>> Refactored the getSolutions method in PSO as well as related topology implementations.*/
     }
 
 //    @Test


### PR DESCRIPTION
...plementations.

getSolutions method now returns solutions on a per-niche bases rather
than a per-neighbourhood bases. For most topologies, this will only
return the global best as most topologies do not have niche related
knowledge. Currently only SpeciationTopology has such knowledge (i.e.
the neighbourhoods corresponds to niches).
