### PR TITLE
Fixed bug in CascadeNetworkExpansionReactionStrategy.

### DIFF
--- a/library/src/main/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/CascadeNetworkExpansionReactionStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/CascadeNetworkExpansionReactionStrategy.java
@@ -57,8 +57,9 @@ public class CascadeNetworkExpansionReactionStrategy<E extends PopulationBasedAl
 
         //add new weights to all the particles in a manner that preserves the old weights
         List<? extends Entity> particles = algorithm.getTopology();
-        int hiddenLayerSize = network.getArchitecture().getArchitectureBuilder().getLayerConfigurations().size() -2;
-        int outputLayerSize = network.getArchitecture().getArchitectureBuilder().getLayerConfigurations().get(2).getSize();
+        int nrOfLayers = network.getArchitecture().getArchitectureBuilder().getLayerConfigurations().size();
+        int hiddenLayerSize = nrOfLayers -2;
+        int outputLayerSize = network.getArchitecture().getArchitectureBuilder().getLayerConfigurations().get(nrOfLayers-1).getSize();
         int inputLayerSize = network.getArchitecture().getArchitectureBuilder().getLayerConfigurations().get(0).getSize();
         if (network.getArchitecture().getArchitectureBuilder().getLayerConfigurations().get(0).isBias()) {
             inputLayerSize += 1;

--- a/library/src/test/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/CascadeNetworkExpansionReactionStrategyTest.java
+++ b/library/src/test/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/CascadeNetworkExpansionReactionStrategyTest.java
@@ -8,6 +8,7 @@ package net.sourceforge.cilib.pso.dynamic.responsestrategies;
 
 import net.sourceforge.cilib.entity.Topologies;
 import net.sourceforge.cilib.io.ARFFFileReader;
+import net.sourceforge.cilib.io.transform.PatternConversionOperator;
 import net.sourceforge.cilib.nn.architecture.builder.CascadeArchitectureBuilder;
 import net.sourceforge.cilib.nn.architecture.builder.LayerConfiguration;
 import net.sourceforge.cilib.nn.architecture.visitors.CascadeVisitor;
@@ -109,6 +110,99 @@ public class CascadeNetworkExpansionReactionStrategyTest {
         Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                                       0.0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0,
                                       0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN),
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getBestPosition());
+    }
+
+    /**
+     *
+     */
+    @Test
+    public void algorithmExecution2() {
+        NNDataTrainingProblem problem = new NNDataTrainingProblem();
+        PatternConversionOperator patternConversion = new PatternConversionOperator();
+        patternConversion.setClassLength(2);
+        problem.setPatternConversionOperator(patternConversion);
+        problem.getDataTableBuilder().setDataReader(new ARFFFileReader());
+        problem.getDataTableBuilder().setSourceURL("library/src/test/resources/datasets/iris.arff");
+        problem.setTrainingSetPercentage(0.7);
+        problem.setGeneralisationSetPercentage(0.3);
+
+        problem.getNeuralNetwork().getArchitecture().setArchitectureBuilder(new CascadeArchitectureBuilder());
+        problem.getNeuralNetwork().setOperationVisitor(new CascadeVisitor());
+        problem.getNeuralNetwork().getArchitecture().getArchitectureBuilder().addLayer(new LayerConfiguration(3));
+        problem.getNeuralNetwork().getArchitecture().getArchitectureBuilder().addLayer(new LayerConfiguration(2));
+        problem.getNeuralNetwork().getArchitecture().getArchitectureBuilder().getLayerBuilder().setDomain("R(-3:3)");
+        problem.initialise();
+
+        PSO pso = new PSO();
+        pso.getInitialisationStrategy().setEntityType(new DynamicParticle());
+        pso.addStoppingCondition(new MeasuredStoppingCondition());
+        pso.setOptimisationProblem(problem);
+        pso.performInitialisation();
+
+        CascadeNetworkExpansionReactionStrategy reaction = new CascadeNetworkExpansionReactionStrategy();
+
+        Assert.assertEquals(8, ((Vector)pso.getBestSolution().getPosition()).size());
+        Assert.assertEquals(8, problem.getNeuralNetwork().getWeights().size());
+
+        for (int i = 0; i < Topologies.getBestEntity(pso.getTopology()).getDimension(); ++i) {
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).set(i, Real.valueOf(0.0));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).set(i, Real.valueOf(0.0));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).set(i, Real.valueOf(0.0));
+        }
+        reaction.performReaction(pso);
+        Assert.assertEquals(14, ((Vector)pso.getBestSolution().getPosition()).size());
+        Assert.assertEquals(14, problem.getNeuralNetwork().getWeights().size());
+        Assert.assertEquals(Vector.of(Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0, 0.0, 0.0, Double.NaN, 0.0,
+                                      0.0, 0.0, 0.0, Double.NaN),
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getPosition());
+        Assert.assertEquals(Vector.of(Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0, 0.0, 0.0, Double.NaN, 0.0,
+                                      0.0, 0.0, 0.0, Double.NaN),
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getVelocity());
+        Assert.assertEquals(Vector.of(Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0, 0.0, 0.0, Double.NaN, 0.0,
+                                      0.0, 0.0, 0.0, Double.NaN),
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getBestPosition());
+
+        for (int i = 0; i < Topologies.getBestEntity(pso.getTopology()).getDimension(); ++i) {
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).set(i, Real.valueOf(0.0));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).set(i, Real.valueOf(0.0));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).set(i, Real.valueOf(0.0));
+        }
+        reaction.performReaction(pso);
+        Assert.assertEquals(21, ((Vector)pso.getBestSolution().getPosition()).size());
+        Assert.assertEquals(21, problem.getNeuralNetwork().getWeights().size());
+        Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0,
+                                      0.0, 0.0, 0.0, 0.0, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                      Double.NaN),
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getPosition());
+        Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0,
+                                      0.0, 0.0, 0.0, 0.0, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                      Double.NaN),
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getVelocity());
+        Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0,
+                                      0.0, 0.0, 0.0, 0.0, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                      Double.NaN),
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getBestPosition());
+
+        for (int i = 0; i < Topologies.getBestEntity(pso.getTopology()).getDimension(); ++i) {
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).set(i, Real.valueOf(0.0));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).set(i, Real.valueOf(0.0));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).set(i, Real.valueOf(0.0));
+        }
+        reaction.performReaction(pso);
+        Assert.assertEquals(29, ((Vector)pso.getBestSolution().getPosition()).size());
+        Assert.assertEquals(29, problem.getNeuralNetwork().getWeights().size());
+        Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN,
+                                      Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                      0.0, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN),
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getPosition());
+        Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN,
+                                      Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                      0.0, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN),
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getVelocity());
+        Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN,
+                                      Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                      0.0, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN),
                             (Vector)Topologies.getBestEntity(pso.getTopology()).getBestPosition());
     }
 }


### PR DESCRIPTION
It incorrectly determined the size of the output layer,
which caused some issues when new weights are added.
