### PR TITLE
ClonedPopulationInit's population size is now a ControlParameter.

### DIFF
--- a/library/src/main/java/net/sourceforge/cilib/algorithm/initialisation/ClonedPopulationInitialisationStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/algorithm/initialisation/ClonedPopulationInitialisationStrategy.java
@@ -115,7 +115,7 @@ public class ClonedPopulationInitialisationStrategy<E extends Entity> implements
         this.entityNumber = ConstantControlParameter.of(entityNumber);
     }
 
-    public void setEntityNumber(ControlParameter entityNumber) {
+    public void setEntityNumberControlParameter(ControlParameter entityNumber) {
         this.entityNumber = entityNumber;
     }
 }


### PR DESCRIPTION
This is necessary for f-race to optimise the population size.
