### PR TITLE
Added NegativeOfControlParameter.

### DIFF
--- a/library/src/main/java/net/sourceforge/cilib/controlparameter/NegativeOfControlParameter.java
+++ b/library/src/main/java/net/sourceforge/cilib/controlparameter/NegativeOfControlParameter.java
@@ -1,0 +1,56 @@
+/**           __  __
+ *    _____ _/ /_/ /_    Computational Intelligence Library (CIlib)
+ *   / ___/ / / / __ \   (c) CIRG @ UP
+ *  / /__/ / / / /_/ /   http://cilib.net
+ *  \___/_/_/_/_.___/
+ */
+package net.sourceforge.cilib.controlparameter;
+
+/**
+ * A {@linkplain net.sourceforge.cilib.controlparameter.ControlParameter control parameter}
+ * to represent the negative of another control parameter.
+ */
+public class NegativeOfControlParameter implements ControlParameter {
+
+    private ControlParameter controlParameter;
+
+    public NegativeOfControlParameter() {
+
+    }
+
+    public NegativeOfControlParameter(NegativeOfControlParameter copy) {
+        this.controlParameter = copy.controlParameter.getClone();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public NegativeOfControlParameter getClone() {
+        return new NegativeOfControlParameter(this);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public double getParameter() {
+        return -controlParameter.getParameter();
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public double getParameter(double min, double max) {
+        throw new UnsupportedOperationException("This operation remains to be implemented.");
+    }
+
+    /**
+     * Sets the control parameter to negate.
+     * @param controlParameter The control parameter.
+     */
+    public void setControlParameter(ControlParameter controlParameter) {
+        this.controlParameter = controlParameter;
+    }
+}

--- a/library/src/test/java/net/sourceforge/cilib/controlparameter/NegativeOfControlParameterTest.java
+++ b/library/src/test/java/net/sourceforge/cilib/controlparameter/NegativeOfControlParameterTest.java
@@ -1,0 +1,23 @@
+/**           __  __
+ *    _____ _/ /_/ /_    Computational Intelligence Library (CIlib)
+ *   / ___/ / / / __ \   (c) CIRG @ UP
+ *  / /__/ / / / /_/ /   http://cilib.net
+ *  \___/_/_/_/_.___/
+ */
+package net.sourceforge.cilib.controlparameter;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import net.sourceforge.cilib.math.Maths;
+
+public class NegativeOfControlParameterTest {
+
+    @Test
+    public void getParameterTest() {
+        ConstantControlParameter parameter = new ConstantControlParameter();
+        parameter.setParameter(5.3);
+        NegativeOfControlParameter negative = new NegativeOfControlParameter();
+        negative.setControlParameter(parameter);
+        assertEquals(-5.3, negative.getParameter(), Maths.EPSILON);
+    }
+}


### PR DESCRIPTION
This wrapper simply negates the ControlParameter that it wraps.

The bounded getParameter method has not been implemented because
I'm not certain of how the bounds are supposed to behave during
negation. I recommend that it remains as such until someone needs
it. That person is more likely to know how it's supposed to behave.
