### PR TITLE
Fixed issue in the way TuningProblem takes measurements.

### DIFF
--- a/library/src/main/java/net/sourceforge/cilib/algorithm/MeasuringListener.java
+++ b/library/src/main/java/net/sourceforge/cilib/algorithm/MeasuringListener.java
@@ -11,17 +11,23 @@ import net.sourceforge.cilib.type.types.Type;
 
 /**
  * This listener takes measurements whenever the target algorithm is started or
- * the target algorithm completes an iteration. The resulting measurement can be
- * retrieved afterwards.
+ * the target algorithm completes a certain interval of iteration. A measurement
+ * always taken after the last iteration, regardless of resolution. The resulting
+ * measurement can be retrieved afterwards.
  */
 public class MeasuringListener implements AlgorithmListener {
 
     private Measurement measurement;
     private Type lastMeasurement;
+    private int resolution;
 
-    public MeasuringListener() {}
+    public MeasuringListener() {
+        resolution = 1;
+    }
 
     public MeasuringListener(MeasuringListener rhs) {
+        resolution = rhs.resolution;
+        
         if (rhs.measurement != null)
             measurement = rhs.measurement.getClone();
 
@@ -44,17 +50,19 @@ public class MeasuringListener implements AlgorithmListener {
     }
 
     /**
-     * This has no effect.
+     * {@inheritDoc}
      */
     public void algorithmFinished(AlgorithmEvent e) {
-        //do nothing
+        if (e.getSource().getIterations() % resolution != 0)
+            lastMeasurement = measurement.getValue(e.getSource());
     }
 
     /**
      * {@inheritDoc}
      */
     public void iterationCompleted(AlgorithmEvent e) {
-        lastMeasurement = measurement.getValue(e.getSource());
+        if (e.getSource().getIterations() % resolution == 0)
+            lastMeasurement = measurement.getValue(e.getSource());
     }
 
     /**
@@ -71,5 +79,14 @@ public class MeasuringListener implements AlgorithmListener {
      */
     public Type getLastMeasurement() {
         return lastMeasurement;
+    }
+
+    /**
+     * Set the interval at which measurements should be taken.
+     * Default value is 1.
+     * @param resolution The resolution to set.
+     */
+    public void setResolution(int resolution) {
+        this.resolution = resolution;
     }
 }

--- a/library/src/main/java/net/sourceforge/cilib/tuning/TuningProblem.java
+++ b/library/src/main/java/net/sourceforge/cilib/tuning/TuningProblem.java
@@ -31,6 +31,7 @@ public class TuningProblem extends AbstractProblem {
     public TuningProblem() {
         this.measurement = new net.sourceforge.cilib.measurement.single.Fitness();
         this.samples = 1;
+        this.measuringListener = new MeasuringListener();
     }
     
     public TuningProblem(TuningProblem copy) {
@@ -38,6 +39,7 @@ public class TuningProblem extends AbstractProblem {
         this.samples = copy.samples;
         this.targetAlgorithm = copy.targetAlgorithm.getClone();
         this.problemsProvider = copy.problemsProvider;
+        this.measuringListener = copy.measuringListener.getClone();
     }
 
     @Override
@@ -105,5 +107,9 @@ public class TuningProblem extends AbstractProblem {
     @Override
     public Objective getObjective() {
         return ((AbstractProblem) currentProblem).getObjective();
+    }
+
+    public void setMeasuringListener(MeasuringListener measuringListener) {
+        this.measuringListener = measuringListener;
     }
 }


### PR DESCRIPTION
TuningPromblem took measurements only after the target algorithm
has finished. This meant that it was incompatible with measurements
that needs information from the entire simulation run. This is has
now been solved with the use of MeasuringListener.

MeasuringListener is an AlgorithmListener that automatically takes
measurements throughout the execution of the target algorithm. The
final measurement can be retrieved afterwards.
