### PR TITLE
Replaced getPosition with getCandidateSolution in Particle related code.

### DIFF
--- a/library/src/main/java/net/sourceforge/cilib/clustering/CooperativePSO.java
+++ b/library/src/main/java/net/sourceforge/cilib/clustering/CooperativePSO.java
@@ -67,7 +67,7 @@ public class CooperativePSO extends MultiPopulationBasedAlgorithm{
     protected void algorithmIteration() {
         iterationStrategy.performIteration(this);
         ClusterParticle particle = ((AbstractCooperativeIterationStrategy) iterationStrategy).getContextParticle();
-        bestSolution = new OptimisationSolution(particle.getPosition(), particle.getFitness());
+        bestSolution = new OptimisationSolution(particle.getCandidateSolution(), particle.getFitness());
     }
 
     /*

--- a/library/src/main/java/net/sourceforge/cilib/clustering/entity/ClusterParticle.java
+++ b/library/src/main/java/net/sourceforge/cilib/clustering/entity/ClusterParticle.java
@@ -97,15 +97,6 @@ public class ClusterParticle extends AbstractParticle{
     }
 
     /*
-     * Returns the current position of the ClusterParticle
-     * @return position The current value of the Candidate Solution
-     */
-    @Override
-    public CentroidHolder getPosition() {
-        return (CentroidHolder) getCandidateSolution();
-    }
-
-    /*
      * Returns the best position acquired by the ClusterParticle so far
      * @return The Personal Best position
      */

--- a/library/src/main/java/net/sourceforge/cilib/clustering/iterationstrategies/CooperativeDataClusteringPSOIterationStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/clustering/iterationstrategies/CooperativeDataClusteringPSOIterationStrategy.java
@@ -98,10 +98,10 @@ public class CooperativeDataClusteringPSOIterationStrategy extends AbstractCoope
 
 
                 if(particleWithContext.getFitness().compareTo(particleWithContext.getBestFitness()) > 0) {
-                    particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getPosition());
+                    particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getCandidateSolution());
                     particle.getProperties().put(EntityType.Particle.BEST_FITNESS, particle.getFitness());
 
-                    particleWithContext.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getPosition());
+                    particleWithContext.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getCandidateSolution());
                     particleWithContext.getProperties().put(EntityType.Particle.BEST_FITNESS, particle.getFitness());
                 }
 
@@ -110,7 +110,7 @@ public class CooperativeDataClusteringPSOIterationStrategy extends AbstractCoope
                 }
 
                 if(contextParticle.getFitness().compareTo(contextParticle.getBestFitness()) > 0) {
-                    contextParticle.getProperties().put(EntityType.Particle.BEST_POSITION, contextParticle.getPosition()).getClone();
+                    contextParticle.getProperties().put(EntityType.Particle.BEST_POSITION, contextParticle.getCandidateSolution()).getClone();
                     contextParticle.getProperties().put(EntityType.Particle.BEST_FITNESS, contextParticle.getFitness()).getClone();
                 }
 

--- a/library/src/main/java/net/sourceforge/cilib/entity/initialisation/StandardPBestPositionInitialisationStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/entity/initialisation/StandardPBestPositionInitialisationStrategy.java
@@ -29,6 +29,6 @@ public class StandardPBestPositionInitialisationStrategy implements Initialisati
 
     @Override
     public void initialise(Enum<?> key, Particle entity) {
-        entity.getProperties().put(EntityType.Particle.BEST_POSITION, entity.getPosition().getClone());
+        entity.getProperties().put(EntityType.Particle.BEST_POSITION, entity.getCandidateSolution().getClone());
     }
 }

--- a/library/src/main/java/net/sourceforge/cilib/measurement/single/NormalisedDiversity.java
+++ b/library/src/main/java/net/sourceforge/cilib/measurement/single/NormalisedDiversity.java
@@ -54,10 +54,10 @@ public class NormalisedDiversity implements Measurement<Real> {
 
         Iterator<Particle> k = pso.getTopology().iterator();
         Particle particle = k.next();
-        Vector averageParticlePosition = (Vector) particle.getPosition().getClone();
+        Vector averageParticlePosition = (Vector) particle.getCandidateSolution().getClone();
         while (k.hasNext()) {
             particle = k.next();
-            Vector v = (Vector) particle.getPosition();
+            Vector v = (Vector) particle.getCandidateSolution();
             for (int j = 0; j < averageParticlePosition.size(); ++j) {
                 averageParticlePosition.setReal(j, averageParticlePosition.doubleValueOf(j) + v.doubleValueOf(j));
             }
@@ -72,7 +72,7 @@ public class NormalisedDiversity implements Measurement<Real> {
             particle = i.next();
 
             double dimensionSum = 0.0;
-            Vector v = (Vector) particle.getPosition();
+            Vector v = (Vector) particle.getCandidateSolution();
             for (int j = 0; j < particle.getDimension(); ++j) {
                 dimensionSum += (v.doubleValueOf(j) - averageParticlePosition.doubleValueOf(j)) * (v.doubleValueOf(j) - averageParticlePosition.doubleValueOf(j));
             }

--- a/library/src/main/java/net/sourceforge/cilib/measurement/single/ParticlePositions.java
+++ b/library/src/main/java/net/sourceforge/cilib/measurement/single/ParticlePositions.java
@@ -46,7 +46,7 @@ public class ParticlePositions implements Measurement<StringType> {
             tmp.append(particle.getBestFitness().getValue());
             tmp.append(" Position: ");
 
-            Vector v = (Vector) particle.getPosition();
+            Vector v = (Vector) particle.getCandidateSolution();
             for (int j = 0; j < particle.getDimension(); ++j) {
                 tmp.append(v.doubleValueOf(j));
                 tmp.append(" ");

--- a/library/src/main/java/net/sourceforge/cilib/pso/DissipativeStep.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/DissipativeStep.java
@@ -66,7 +66,7 @@ public class DissipativeStep {
                 /*particle.getPosition()[i] = randomGenerator.nextDouble()
                 //* (d.getUpperBound() - d.getLowerBound()) + d.getLowerBound();
                 * (component.getUpperBound() - component.getLowerBound()) + component.getLowerBound();*/
-                Vector position = (Vector) particle.getPosition();
+                Vector position = (Vector) particle.getCandidateSolution();
                 position.setReal(i, Rand.nextDouble()*(component.getBounds().getUpperBound() - component.getBounds().getLowerBound())+ component.getBounds().getLowerBound());
             }
         }

--- a/library/src/main/java/net/sourceforge/cilib/pso/crossover/pbestupdate/CurrentPositionOffspringPBestProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/crossover/pbestupdate/CurrentPositionOffspringPBestProvider.java
@@ -16,6 +16,6 @@ import net.sourceforge.cilib.type.types.container.StructuredType;
 public class CurrentPositionOffspringPBestProvider extends OffspringPBestProvider {
     @Override
     public StructuredType f(List<Particle> parent, Particle offspring) {
-        return offspring.getPosition();
+        return offspring.getCandidateSolution();
     }
 }

--- a/library/src/main/java/net/sourceforge/cilib/pso/crossover/pbestupdate/RandomOffspringPBestProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/crossover/pbestupdate/RandomOffspringPBestProvider.java
@@ -18,6 +18,6 @@ import net.sourceforge.cilib.type.types.container.Vector;
 public class RandomOffspringPBestProvider extends OffspringPBestProvider {
     @Override
     public StructuredType f(List<Particle> parent, Particle offspring) {
-        return Vector.newBuilder().copyOf(offspring.getPosition()).buildRandom();
+        return Vector.newBuilder().copyOf((Vector) offspring.getCandidateSolution()).buildRandom();
     }
 }

--- a/library/src/main/java/net/sourceforge/cilib/pso/crossover/velocityprovider/VelocityUpdateOffspringVelocityProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/crossover/velocityprovider/VelocityUpdateOffspringVelocityProvider.java
@@ -52,7 +52,7 @@ public class VelocityUpdateOffspringVelocityProvider extends OffspringVelocityPr
 
     @Override
     public StructuredType f(List<Particle> parents, Particle offspring) {
-        Vector position = (Vector) offspring.getPosition();
+        Vector position = (Vector) offspring.getCandidateSolution();
         Vector localGuide = (Vector) new ElitistSelector<Particle>().on(parents).select().getBestPosition();
         Vector globalGuide = (Vector) AbstractAlgorithm.get().getBestSolution().getPosition();
 

--- a/library/src/main/java/net/sourceforge/cilib/pso/dynamic/ChargedParticle.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/dynamic/ChargedParticle.java
@@ -79,8 +79,8 @@ public class ChargedParticle extends DynamicParticle {
     @Override
     public void initialise(Problem problem) {
         this.getProperties().put(EntityType.CANDIDATE_SOLUTION, problem.getDomain().getBuiltRepresentation().getClone());
-        this.getProperties().put(EntityType.Particle.BEST_POSITION, Vector.copyOf(getPosition()));
-        this.getProperties().put(EntityType.Particle.VELOCITY, Vector.copyOf(getPosition()));
+        this.getProperties().put(EntityType.Particle.BEST_POSITION, Vector.copyOf((Vector) getCandidateSolution()));
+        this.getProperties().put(EntityType.Particle.VELOCITY, Vector.copyOf((Vector) getCandidateSolution()));
 
         this.positionInitialisationStrategy.initialise(EntityType.CANDIDATE_SOLUTION, this);
         this.personalBestInitialisationStrategy.initialise(EntityType.Particle.BEST_POSITION, this);

--- a/library/src/main/java/net/sourceforge/cilib/pso/dynamic/ChargedVelocityProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/dynamic/ChargedVelocityProvider.java
@@ -48,7 +48,7 @@ public class ChargedVelocityProvider implements VelocityProvider {
 
     @Override
     public Vector get(Particle particle) {
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
 
         PSO pso = (PSO) AbstractAlgorithm.get();
 
@@ -63,7 +63,7 @@ public class ChargedVelocityProvider implements VelocityProvider {
 
                 double qi = ((ChargedParticle) particle).getCharge();
                 double qj = ((ChargedParticle) other).getCharge();
-                Vector rij = position.subtract((Vector) other.getPosition());
+                Vector rij = position.subtract((Vector) other.getCandidateSolution());
                 double magnitude = rij.norm();
 
                 if (this.pCore.getParameter() <= magnitude && magnitude <= this.p.getParameter()) {

--- a/library/src/main/java/net/sourceforge/cilib/pso/dynamic/detectionstrategies/RandomSentryDetectionStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/dynamic/detectionstrategies/RandomSentryDetectionStrategy.java
@@ -90,7 +90,7 @@ public class RandomSentryDetectionStrategy extends EnvironmentChangeDetectionStr
 
         for (Particle nextSentry : sentryList) {
             double oldSentryFitness = nextSentry.getFitness().getValue();
-            double newSentryFitness = algorithm.getOptimisationProblem().getFitness(nextSentry.getPosition()).getValue();
+            double newSentryFitness = algorithm.getOptimisationProblem().getFitness(nextSentry.getCandidateSolution()).getValue();
 
             if(Math.abs(oldSentryFitness - newSentryFitness) >=  theta) {
                 envChangeOccured = true;

--- a/library/src/main/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/CascadeNetworkExpansionReactionStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/CascadeNetworkExpansionReactionStrategy.java
@@ -14,6 +14,7 @@ import net.sourceforge.cilib.nn.architecture.builder.LayerConfiguration;
 import net.sourceforge.cilib.problem.nn.NNDataTrainingProblem;
 import net.sourceforge.cilib.pso.dynamic.DynamicParticle;
 import net.sourceforge.cilib.pso.particle.Particle;
+import net.sourceforge.cilib.type.types.container.Vector;
 import net.sourceforge.cilib.type.types.Bounds;
 import net.sourceforge.cilib.type.types.Real;
 
@@ -67,13 +68,13 @@ public class CascadeNetworkExpansionReactionStrategy<E extends SinglePopulationB
         }
         for (Entity curParticle : particles) {
             DynamicParticle curDynamicParticle = (DynamicParticle)curParticle;
-            Bounds bounds = curDynamicParticle.getPosition().get(0).getBounds();
+            Bounds bounds = ((Vector) curDynamicParticle.getCandidateSolution()).get(0).getBounds();
 
             //add weights of new neuron
             int addPosition = inputLayerSize * (hiddenLayerSize-1);
             addPosition += (hiddenLayerSize-2)*(hiddenLayerSize-1)/2;
             for (int i = 0; i < inputLayerSize + hiddenLayerSize-1; ++i) {
-                curDynamicParticle.getPosition().insert(addPosition, Real.valueOf(Double.NaN, bounds));
+                ((Vector) curDynamicParticle.getCandidateSolution()).insert(addPosition, Real.valueOf(Double.NaN, bounds));
                 curDynamicParticle.getBestPosition().insert(addPosition, Real.valueOf(Double.NaN, bounds));
                 curDynamicParticle.getVelocity().insert(addPosition, Real.valueOf(Double.NaN, bounds));
             }
@@ -84,7 +85,7 @@ public class CascadeNetworkExpansionReactionStrategy<E extends SinglePopulationB
             for (int curOutput = 0; curOutput < outputLayerSize; ++curOutput) {
                 addPosition = startAddPosition + (curOutput+1)*(inputLayerSize + hiddenLayerSize) -1;
 
-                curDynamicParticle.getPosition().insert(addPosition, Real.valueOf(Double.NaN, bounds));
+                ((Vector) curDynamicParticle.getCandidateSolution()).insert(addPosition, Real.valueOf(Double.NaN, bounds));
                 curDynamicParticle.getBestPosition().insert(addPosition, Real.valueOf(Double.NaN, bounds));
                 curDynamicParticle.getVelocity().insert(addPosition, Real.valueOf(Double.NaN, bounds));
             }

--- a/library/src/main/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/InitialiseNaNElementsReactionStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/InitialiseNaNElementsReactionStrategy.java
@@ -46,7 +46,7 @@ public class InitialiseNaNElementsReactionStrategy<E extends SinglePopulationBas
         for (Entity entity : entities) {
             DynamicParticle particle = (DynamicParticle) entity;
             //initialise position
-            Vector position = (Vector) particle.getPosition();
+            Vector position = (Vector) particle.getCandidateSolution();
             for (int curElement = 0; curElement < position.size(); ++curElement) {
                 if (Double.isNaN(position.doubleValueOf(curElement))) {
                     position.get(curElement).randomise();

--- a/library/src/main/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/PartialReinitialisationResponseStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/PartialReinitialisationResponseStrategy.java
@@ -62,15 +62,15 @@ public class PartialReinitialisationResponseStrategy extends ParticleReevaluatio
 
             //makes sure the charged particles are randomly positioned across the topology
             if (reinitCounter < Math.floor(populationSize * reinitialisationRatio) && Rand.nextDouble() < reinitialisationRatio && current != Topologies.getBestEntity(algorithm.getTopology())) {
-                current.getPosition().randomise();
+                ((Vector) current.getCandidateSolution()).randomise();
                 current.getProperties().put(EntityType.Particle.VELOCITY, Vectors.transform(current.getVelocity(), zt));
-                current.getProperties().put(EntityType.Particle.BEST_POSITION, Vector.copyOf(current.getPosition()));
+                current.getProperties().put(EntityType.Particle.BEST_POSITION, Vector.copyOf((Vector) current.getCandidateSolution()));
                 ++reinitCounter;
             }//if
             else if (keepCounter > Math.floor(populationSize * (1.0 - reinitialisationRatio)) && current != Topologies.getBestEntity(algorithm.getTopology())) {
-                current.getPosition().randomise();
+                ((Vector) current.getCandidateSolution()).randomise();
                 current.getProperties().put(EntityType.Particle.VELOCITY, Vectors.transform(current.getVelocity(), zt));
-                current.getProperties().put(EntityType.Particle.BEST_POSITION, Vector.copyOf(current.getPosition()));
+                current.getProperties().put(EntityType.Particle.BEST_POSITION, Vector.copyOf((Vector) current.getCandidateSolution()));
                 ++reinitCounter;
             }//else if
             else {

--- a/library/src/main/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/ReinitialiseCascadeNetworkOutputWeightsReactionStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/ReinitialiseCascadeNetworkOutputWeightsReactionStrategy.java
@@ -64,7 +64,7 @@ public class ReinitialiseCascadeNetworkOutputWeightsReactionStrategy<E extends S
         for (Entity entity : entities) {
             DynamicParticle particle = (DynamicParticle) entity;
 
-            Vector position = (Vector) particle.getPosition();
+            Vector position = (Vector) particle.getCandidateSolution();
             Vector velocity = (Vector) particle.getVelocity();
             for (int curElement = position.size() - nrOfweightsToDo; curElement < position.size(); ++curElement) {
                 ((Real) position.get(curElement)).randomise();

--- a/library/src/main/java/net/sourceforge/cilib/pso/hpso/AdaptiveLearningIterationStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/hpso/AdaptiveLearningIterationStrategy.java
@@ -177,12 +177,12 @@ public class AdaptiveLearningIterationStrategy extends AbstractIterationStrategy
                 updateProgressAndReward(props.common, i, particle, prevFitness);
 
                 //gbestupdate with abest
-                for(int j = 0; j < particle.getPosition().size(); j++) {
+                for(int j = 0; j < particle.getCandidateSolution().size(); j++) {
                     if(random.getRandomNumber() < props.learningProbability) {
                         Particle aBestClone = aBest.getClone();
                         Vector aBestVector = (Vector) aBestClone.getBestPosition();
 
-                        aBestVector.setReal(j, ((Vector)particle.getPosition()).doubleValueOf(j));
+                        aBestVector.setReal(j, ((Vector)particle.getCandidateSolution()).doubleValueOf(j));
                         aBestClone.setCandidateSolution(aBestVector);
                         Fitness fitness = particle.getFitnessCalculator().getFitness(aBestClone);
 
@@ -202,7 +202,7 @@ public class AdaptiveLearningIterationStrategy extends AbstractIterationStrategy
 
                 //set abest
                 if(aBest.getBestFitness().compareTo(particle.getFitness()) < 0) {
-                    aBest.getProperties().put(BEST_POSITION, particle.getPosition().getClone());
+                    aBest.getProperties().put(BEST_POSITION, particle.getCandidateSolution().getClone());
                     aBest.getProperties().put(BEST_FITNESS, particle.getFitness().getClone());
                 }
             }

--- a/library/src/main/java/net/sourceforge/cilib/pso/multiswarm/CooperativeMultiswarmIterationStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/multiswarm/CooperativeMultiswarmIterationStrategy.java
@@ -91,7 +91,7 @@ public class CooperativeMultiswarmIterationStrategy extends AbstractCooperativeI
                         particleWithContext.calculateFitness();
 
                         if(particleWithContext.getFitness().compareTo(particleWithContext.getBestFitness()) > 0) {
-                            particleWithContext.getProperties().put(EntityType.Particle.BEST_POSITION, particleWithContext.getPosition().getClone());
+                            particleWithContext.getProperties().put(EntityType.Particle.BEST_POSITION, particleWithContext.getCandidateSolution().getClone());
                             particleWithContext.getProperties().put(EntityType.Particle.BEST_FITNESS, particleWithContext.getFitness().getClone());
                         }
 
@@ -100,7 +100,7 @@ public class CooperativeMultiswarmIterationStrategy extends AbstractCooperativeI
                         }
 
                         if(contextParticle.getFitness().compareTo(contextParticle.getBestFitness()) > 0) {
-                            contextParticle.getProperties().put(EntityType.Particle.BEST_POSITION, contextParticle.getPosition().getClone());
+                            contextParticle.getProperties().put(EntityType.Particle.BEST_POSITION, contextParticle.getCandidateSolution().getClone());
                             contextParticle.getProperties().put(EntityType.Particle.BEST_FITNESS, contextParticle.getFitness().getClone());
                         }
 

--- a/library/src/main/java/net/sourceforge/cilib/pso/particle/AbstractParticle.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/particle/AbstractParticle.java
@@ -108,13 +108,6 @@ public abstract class AbstractParticle extends AbstractEntity implements Particl
     public abstract Fitness getBestFitness();
 
     /**
-     * Get the position of the {@code Particle}.
-     * @return A {@link StructuredType} representing the {@code Particle}'s position.
-     */
-    @Override
-    public abstract StructuredType getPosition();
-
-    /**
      * Get the best position of the {@code Particle}.
      * @return A {@link StructuredType} representing the {@code Particle}'s best position.
      */

--- a/library/src/main/java/net/sourceforge/cilib/pso/particle/Particle.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/particle/Particle.java
@@ -28,12 +28,6 @@ public interface Particle extends Entity, SocialEntity, MemoryBasedEntity {
     Particle getClone();
 
     /**
-     * Get the current position of the {@linkplain Particle}.
-     * @return The {@linkplain Type} representing the position.
-     */
-    StructuredType getPosition();
-
-    /**
      * Get the current velocity of the {@linkplain Particle}.
      * @return The {@linkplain Type} representing the velocity.
      */

--- a/library/src/main/java/net/sourceforge/cilib/pso/particle/StandardParticle.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/particle/StandardParticle.java
@@ -92,14 +92,6 @@ public class StandardParticle extends AbstractParticle {
      * {@inheritDoc}
      */
     @Override
-    public Vector getPosition() {
-        return (Vector) getCandidateSolution();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public Vector getVelocity() {
         return (Vector) this.getProperties().get(EntityType.Particle.VELOCITY);
     }
@@ -110,8 +102,8 @@ public class StandardParticle extends AbstractParticle {
     @Override
     public void initialise(Problem problem) {
         this.getProperties().put(EntityType.CANDIDATE_SOLUTION, problem.getDomain().getBuiltRepresentation().getClone());
-        this.getProperties().put(EntityType.Particle.BEST_POSITION, Vector.copyOf(getPosition()));
-        this.getProperties().put(EntityType.Particle.VELOCITY, Vector.copyOf(getPosition()));
+        this.getProperties().put(EntityType.Particle.BEST_POSITION, Vector.copyOf((Vector) getCandidateSolution()));
+        this.getProperties().put(EntityType.Particle.VELOCITY, Vector.copyOf((Vector) getCandidateSolution()));
 
         this.positionInitialisationStrategy.initialise(EntityType.CANDIDATE_SOLUTION, this);
         this.personalBestInitialisationStrategy.initialise(EntityType.Particle.BEST_POSITION, this);

--- a/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/BoundedDominantPersonalBestUpdateStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/BoundedDominantPersonalBestUpdateStrategy.java
@@ -32,7 +32,7 @@ public class BoundedDominantPersonalBestUpdateStrategy extends DominantPersonalB
      */
     @Override
     public void updatePersonalBest(Particle particle) {
-        if (!Types.isInsideBounds(particle.getPosition())) {
+        if (!Types.isInsideBounds(particle.getCandidateSolution())) {
             particle.getProperties().put(EntityType.FITNESS, InferiorFitness.instance());
             return;
         }

--- a/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/BoundedMOOStandardPersonalBestUpdateStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/BoundedMOOStandardPersonalBestUpdateStrategy.java
@@ -35,7 +35,7 @@ public class BoundedMOOStandardPersonalBestUpdateStrategy extends MOOStandardPer
      */
     @Override
     public void updatePersonalBest(Particle particle) {
-        if (!Types.isInsideBounds(particle.getPosition())) {
+        if (!Types.isInsideBounds(particle.getCandidateSolution())) {
             particle.getProperties().put(EntityType.FITNESS, InferiorFitness.instance());
             return;
         }

--- a/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/BoundedNonDominatedPersonalBestUpdateStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/BoundedNonDominatedPersonalBestUpdateStrategy.java
@@ -36,7 +36,7 @@ public class BoundedNonDominatedPersonalBestUpdateStrategy extends NonDominatedP
      */
     @Override
     public void updatePersonalBest(Particle particle) {
-        if (!Types.isInsideBounds(particle.getPosition())) {
+        if (!Types.isInsideBounds(particle.getCandidateSolution())) {
             particle.getProperties().put(EntityType.FITNESS, InferiorFitness.instance());
             return;
         }

--- a/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/BoundedPersonalBestUpdateStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/BoundedPersonalBestUpdateStrategy.java
@@ -46,7 +46,7 @@ public class BoundedPersonalBestUpdateStrategy implements PersonalBestUpdateStra
      */
     @Override
     public void updatePersonalBest(Particle particle) {
-        if (!Types.isInsideBounds(particle.getPosition())) {
+        if (!Types.isInsideBounds(particle.getCandidateSolution())) {
             particle.getProperties().put(EntityType.FITNESS, InferiorFitness.instance());
             return;
         }

--- a/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/BoundedRelaxedNonDominatedPersonalBestUpdateStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/BoundedRelaxedNonDominatedPersonalBestUpdateStrategy.java
@@ -29,7 +29,7 @@ public class BoundedRelaxedNonDominatedPersonalBestUpdateStrategy extends Relaxe
      */
     @Override
     public void updatePersonalBest(Particle particle) {
-        if (!Types.isInsideBounds(particle.getPosition())) {
+        if (!Types.isInsideBounds(particle.getCandidateSolution())) {
             particle.getProperties().put(EntityType.FITNESS, InferiorFitness.instance());
             return;
         }

--- a/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/DominantPersonalBestUpdateStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/DominantPersonalBestUpdateStrategy.java
@@ -45,18 +45,18 @@ public class DominantPersonalBestUpdateStrategy implements PersonalBestUpdateStr
         Problem problem = topLevelAlgorithm.getOptimisationProblem();
 
         if (particle.getFitness().getClass().getName().matches("MinimisationFitness")) {
-         if ((particle.getBestFitness() == null) || (problem.getFitness(particle.getPosition()).compareTo(problem.getFitness(particle.getBestPosition())) > 0)) {
+         if ((particle.getBestFitness() == null) || (problem.getFitness(particle.getCandidateSolution()).compareTo(problem.getFitness(particle.getBestPosition())) > 0)) {
             particle.getProperties().put(EntityType.Particle.Count.PBEST_STAGNATION_COUNTER, Int.valueOf(0));
             particle.getProperties().put(EntityType.Particle.BEST_FITNESS, particle.getFitness().getClone());
-            particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getPosition().getClone());
+            particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getCandidateSolution().getClone());
             return;
          }
         }
          else if (particle.getFitness().getClass().getName().matches("StandardMOFitness")) {
-             if ((((MOFitness)particle.getBestFitness()) == null) || (((MOFitness)problem.getFitness(particle.getPosition())).compareTo(((MOFitness)problem.getFitness(particle.getBestPosition()))) > 0)) {
+             if ((((MOFitness)particle.getBestFitness()) == null) || (((MOFitness)problem.getFitness(particle.getCandidateSolution())).compareTo(((MOFitness)problem.getFitness(particle.getBestPosition()))) > 0)) {
                 particle.getProperties().put(EntityType.Particle.Count.PBEST_STAGNATION_COUNTER, Int.valueOf(0));
                 particle.getProperties().put(EntityType.Particle.BEST_FITNESS, particle.getFitness().getClone());
-                particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getPosition().getClone());
+                particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getCandidateSolution().getClone());
                 return;
             }
          }

--- a/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/MOOStandardPersonalBestUpdateStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/MOOStandardPersonalBestUpdateStrategy.java
@@ -45,10 +45,10 @@ public class MOOStandardPersonalBestUpdateStrategy implements PersonalBestUpdate
         Algorithm topLevelAlgorithm = AbstractAlgorithm.getAlgorithmList().get(0);
         Problem problem = topLevelAlgorithm.getOptimisationProblem();
 
-        if ((particle.getBestFitness() == null) || (problem.getFitness(particle.getPosition()).compareTo(problem.getFitness(particle.getBestPosition())) > 0)) {
+        if ((particle.getBestFitness() == null) || (problem.getFitness(particle.getCandidateSolution()).compareTo(problem.getFitness(particle.getBestPosition())) > 0)) {
             particle.getProperties().put(EntityType.Particle.Count.PBEST_STAGNATION_COUNTER, Int.valueOf(0));
             particle.getProperties().put(EntityType.Particle.BEST_FITNESS, particle.getFitness());
-            particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getPosition().getClone());
+            particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getCandidateSolution().getClone());
             return;
         }
 

--- a/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/NonDominatedPersonalBestUpdateStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/NonDominatedPersonalBestUpdateStrategy.java
@@ -43,18 +43,18 @@ public class NonDominatedPersonalBestUpdateStrategy implements PersonalBestUpdat
         Problem problem = topLevelAlgorithm.getOptimisationProblem();
 
         if (particle.getFitness().getClass().getName().matches("MinimisationFitness")) {
-         if ((particle.getBestFitness() == null) || (problem.getFitness(particle.getPosition()).compareTo(problem.getFitness(particle.getBestPosition())) >= 0)) {
+         if ((particle.getBestFitness() == null) || (problem.getFitness(particle.getCandidateSolution()).compareTo(problem.getFitness(particle.getBestPosition())) >= 0)) {
             particle.getProperties().put(EntityType.Particle.Count.PBEST_STAGNATION_COUNTER, Int.valueOf(0));
             particle.getProperties().put(EntityType.Particle.BEST_FITNESS, particle.getFitness().getClone());
-            particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getPosition().getClone());
+            particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getCandidateSolution().getClone());
             return;
          }
         }
          else if (particle.getFitness().getClass().getName().matches("StandardMOFitness")) {
-             if ((((MOFitness)particle.getBestFitness()) == null) || (((MOFitness)problem.getFitness(particle.getPosition())).compareTo(((MOFitness)problem.getFitness(particle.getBestPosition()))) >= 0)) {
+             if ((((MOFitness)particle.getBestFitness()) == null) || (((MOFitness)problem.getFitness(particle.getCandidateSolution())).compareTo(((MOFitness)problem.getFitness(particle.getBestPosition()))) >= 0)) {
                 particle.getProperties().put(EntityType.Particle.Count.PBEST_STAGNATION_COUNTER, Int.valueOf(0));
                 particle.getProperties().put(EntityType.Particle.BEST_FITNESS, particle.getFitness().getClone());
-                particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getPosition().getClone());
+                particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getCandidateSolution().getClone());
                 return;
             }
          }

--- a/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/RelaxedNonDominatedPersonalBestUpdateStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/RelaxedNonDominatedPersonalBestUpdateStrategy.java
@@ -43,35 +43,35 @@ public class RelaxedNonDominatedPersonalBestUpdateStrategy implements PersonalBe
         Problem problem = topLevelAlgorithm.getOptimisationProblem();
 
         if (particle.getFitness().getClass().getName().matches("MinimisationFitness")) {
-         if ((particle.getBestFitness() == null) || (problem.getFitness(particle.getPosition()).compareTo(problem.getFitness(particle.getBestPosition())) > 0)) {
+         if ((particle.getBestFitness() == null) || (problem.getFitness(particle.getCandidateSolution()).compareTo(problem.getFitness(particle.getBestPosition())) > 0)) {
             particle.getProperties().put(EntityType.Particle.Count.PBEST_STAGNATION_COUNTER, Int.valueOf(0));
             particle.getProperties().put(EntityType.Particle.BEST_FITNESS, particle.getFitness().getClone());
-            particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getPosition().getClone());
+            particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getCandidateSolution().getClone());
             return;
          }
-         else if ((particle.getBestFitness() == null) || (problem.getFitness(particle.getPosition()).compareTo(problem.getFitness(particle.getBestPosition())) == 0)) {
+         else if ((particle.getBestFitness() == null) || (problem.getFitness(particle.getCandidateSolution()).compareTo(problem.getFitness(particle.getBestPosition())) == 0)) {
             int random = Rand.nextInt(2);
             if (random == 1) {
                 particle.getProperties().put(EntityType.Particle.Count.PBEST_STAGNATION_COUNTER, Int.valueOf(0));
                 particle.getProperties().put(EntityType.Particle.BEST_FITNESS, particle.getFitness().getClone());
-                particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getPosition().getClone());
+                particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getCandidateSolution().getClone());
                 return;
             }
          }
         }
          else if (particle.getFitness().getClass().getName().matches("StandardMOFitness")) {
-             if ((((MOFitness)particle.getBestFitness()) == null) || (((MOFitness)problem.getFitness(particle.getPosition())).compareTo(((MOFitness)problem.getFitness(particle.getBestPosition()))) > 0)) {
+             if ((((MOFitness)particle.getBestFitness()) == null) || (((MOFitness)problem.getFitness(particle.getCandidateSolution())).compareTo(((MOFitness)problem.getFitness(particle.getBestPosition()))) > 0)) {
                 particle.getProperties().put(EntityType.Particle.Count.PBEST_STAGNATION_COUNTER, Int.valueOf(0));
                 particle.getProperties().put(EntityType.Particle.BEST_FITNESS, particle.getFitness().getClone());
-                particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getPosition().getClone());
+                particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getCandidateSolution().getClone());
                 return;
             }
-            else if ((((MOFitness)particle.getBestFitness()) == null) || (((MOFitness)problem.getFitness(particle.getPosition())).compareTo(((MOFitness)problem.getFitness(particle.getBestPosition()))) == 0)) {
+            else if ((((MOFitness)particle.getBestFitness()) == null) || (((MOFitness)problem.getFitness(particle.getCandidateSolution())).compareTo(((MOFitness)problem.getFitness(particle.getBestPosition()))) == 0)) {
                 int random = Rand.nextInt(20);
                 if (random > 10) {
                     particle.getProperties().put(EntityType.Particle.Count.PBEST_STAGNATION_COUNTER, Int.valueOf(0));
                     particle.getProperties().put(EntityType.Particle.BEST_FITNESS, particle.getFitness().getClone());
-                    particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getPosition().getClone());
+                    particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getCandidateSolution().getClone());
                     return;
                 }
             }

--- a/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/StandardPersonalBestUpdateStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/pbestupdate/StandardPersonalBestUpdateStrategy.java
@@ -43,7 +43,7 @@ public class StandardPersonalBestUpdateStrategy implements PersonalBestUpdateStr
             particle.getParticleBehavior().incrementSuccessCounter();
             particle.getProperties().put(EntityType.Particle.Count.PBEST_STAGNATION_COUNTER, Int.valueOf(0));
             particle.getProperties().put(EntityType.Particle.BEST_FITNESS, particle.getFitness());
-            particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getPosition().getClone());
+            particle.getProperties().put(EntityType.Particle.BEST_POSITION, particle.getCandidateSolution().getClone());
             return;
         }
 

--- a/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/DEPositionProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/DEPositionProvider.java
@@ -56,7 +56,7 @@ public class DEPositionProvider implements PositionProvider {
 
     @Override
     public Vector get(Particle particle) {
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
         Vector velocity = (Vector) particle.getVelocity();
 
         if (rand1.getRandomNumber() < differentialEvolutionProbability.getRandomNumber(0.8, 0.1)) {

--- a/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/StandardPositionProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/StandardPositionProvider.java
@@ -42,7 +42,7 @@ public class StandardPositionProvider implements PositionProvider {
      */
     @Override
     public Vector get(Particle particle) {
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
         Vector velocity = (Vector) particle.getVelocity();
         return position.plus(velocity);
     }

--- a/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/TwoStepPositionProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/TwoStepPositionProvider.java
@@ -60,7 +60,7 @@ public class TwoStepPositionProvider implements PositionProvider {
         Vector velocity = (Vector) particle.getVelocity();
         double beta = this.beta.getParameter();
 
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
         Vector position1 = position.plus(velocity);
         Vector position2 = position.plus(velocity.multiply(beta));
 

--- a/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/VectorBasedPositionProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/VectorBasedPositionProvider.java
@@ -62,7 +62,7 @@ public class VectorBasedPositionProvider implements PositionProvider {
                 .subtract(newPos).dot(newPBest.subtract(newPos));
 
         if (dot < 0) {
-            return (Vector) particle.getPosition();
+            return (Vector) particle.getCandidateSolution();
         }
 
         return newPos;

--- a/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/binary/BinaryComplementaryPositionProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/binary/BinaryComplementaryPositionProvider.java
@@ -56,7 +56,7 @@ public class BinaryComplementaryPositionProvider implements PositionProvider {
     @Override
     public Vector get(Particle particle) {
         Vector velocity = (Vector) particle.getVelocity();
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
 
         Vector.Builder builder = Vector.newBuilder();
         for (int i = 0; i < particle.getDimension(); i++) {

--- a/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/binary/BinaryInertiaPositionProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/binary/BinaryInertiaPositionProvider.java
@@ -62,7 +62,7 @@ public class BinaryInertiaPositionProvider implements PositionProvider {
     public Vector get(Particle particle) {
 
         Vector velocity = (Vector) particle.getVelocity();
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
         Vector.Builder builder = Vector.newBuilder();
 
         for (int i = 0; i < particle.getDimension(); i++) {

--- a/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/binary/BinaryQuantumPositionProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/binary/BinaryQuantumPositionProvider.java
@@ -41,7 +41,7 @@ public class BinaryQuantumPositionProvider implements PositionProvider {
     @Override
     public Vector get(Particle particle) {
         Vector velocity = (Vector) particle.getVelocity();
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
         Vector.Builder builder = Vector.newBuilder();
 
         for (int i = 0; i < particle.getDimension(); i++) {

--- a/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/binary/BinaryStaticProbPositionProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/positionprovider/binary/BinaryStaticProbPositionProvider.java
@@ -61,7 +61,7 @@ public class BinaryStaticProbPositionProvider implements PositionProvider {
     @Override
     public Vector get(Particle particle) {
         Vector velocity = (Vector) particle.getVelocity();
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
         Vector pbest = (Vector) particle.getLocalGuide();
         Vector gbest = (Vector) particle.getGlobalGuide();
         Vector.Builder builder = Vector.newBuilder();

--- a/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/BareBonesDEVelocityProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/BareBonesDEVelocityProvider.java
@@ -96,7 +96,7 @@ public class BareBonesDEVelocityProvider implements VelocityProvider {
             if (this.rand2.getRandomNumber(0, 1) > this.crossoverProbability.getParameter()) {
                 builder.add(attractor + stepSize);
             } else {
-                builder.add(((Vector) particle.getPosition()).doubleValueOf(i));
+                builder.add(((Vector) particle.getCandidateSolution()).doubleValueOf(i));
             }
         }
         return builder.build();

--- a/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/ConstrictionVelocityProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/ConstrictionVelocityProvider.java
@@ -129,7 +129,7 @@ public class ConstrictionVelocityProvider implements VelocityProvider {
         }
 
         Vector velocity = (Vector) particle.getVelocity();
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
         Vector localGuide = (Vector) particle.getLocalGuide();
         Vector globalGuide = (Vector) particle.getGlobalGuide();
 

--- a/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/FDRVelocityProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/FDRVelocityProvider.java
@@ -79,7 +79,7 @@ public class FDRVelocityProvider implements VelocityProvider {
      */
     @Override
     public Vector get(Particle particle) {
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
 
         Vector standardVelocity = this.delegate.get(particle);
 

--- a/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/FIPSVelocityProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/FIPSVelocityProvider.java
@@ -42,7 +42,7 @@ public class FIPSVelocityProvider implements VelocityProvider {
     @Override
     public Vector get(Particle particle) {
         Vector velocity = (Vector) particle.getVelocity();
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
         PSO algorithm = (PSO) AbstractAlgorithm.get();
         fj.data.List<Particle> topology = algorithm.getTopology();
 

--- a/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/GCVelocityProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/GCVelocityProvider.java
@@ -123,7 +123,7 @@ public class GCVelocityProvider implements VelocityProvider {
 
         if (particle == globalBest) {
             final Vector velocity = (Vector) particle.getVelocity();
-            final Vector position = (Vector) particle.getPosition();
+            final Vector position = (Vector) particle.getCandidateSolution();
             final Vector globalGuide = (Vector) particle.getGlobalGuide();
 
             Vector.Builder builder = Vector.newBuilder();
@@ -165,7 +165,7 @@ public class GCVelocityProvider implements VelocityProvider {
                 this.failureCount++;
             }
 
-            updateRho((Vector) particle.getPosition());
+            updateRho((Vector) particle.getCandidateSolution());
             return;
         }
 

--- a/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/LinearVelocityProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/LinearVelocityProvider.java
@@ -54,7 +54,7 @@ public class LinearVelocityProvider implements VelocityProvider {
     @Override
     public Vector get(Particle particle) {
         Vector velocity = (Vector) particle.getVelocity();
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
         Vector localGuide = (Vector) particle.getLocalGuide();
         Vector globalGuide = (Vector) particle.getGlobalGuide();
 

--- a/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/MOVelocityProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/MOVelocityProvider.java
@@ -63,7 +63,7 @@ public final class MOVelocityProvider implements VelocityProvider {
     public Vector get(Particle particle) {
 
         Vector velocity = (Vector) particle.getVelocity();
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
         Vector gbest = (Vector) particle.getNeighbourhoodBest().getCandidateSolution();
         Vector localGuide = (Vector) particle.getLocalGuide();
         Vector globalGuide = (Vector) particle.getGlobalGuide();

--- a/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/PredatorVelocityProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/PredatorVelocityProvider.java
@@ -61,7 +61,7 @@ public final class PredatorVelocityProvider implements VelocityProvider {
      */
     @Override
     public Vector get(Particle particle) {
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
         Vector globalGuide = (Vector) particle.getGlobalGuide();
 
         double phi4 = acceleration.getParameter() * Rand.nextDouble();

--- a/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/PreyVelocityProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/PreyVelocityProvider.java
@@ -81,7 +81,7 @@ public final class PreyVelocityProvider implements VelocityProvider {
      */
     @Override
     public Vector get(Particle particle) {
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
         Vector standardVelocity = delegate.get(particle);
         Vector.Builder builder = Vector.newBuilder();
         List<Particle> predators = getPredators();
@@ -102,7 +102,7 @@ public final class PreyVelocityProvider implements VelocityProvider {
                 double predatorPosition = 0;
 
                 for (Particle p : predators) {
-                    Vector predatorPos = (Vector)p.getPosition();
+                    Vector predatorPos = (Vector)p.getCandidateSolution();
                     double xp = predatorPos.doubleValueOf(i);
                     if (Math.abs(x - xp) < min) {
                         predatorPosition = xp;

--- a/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/StandardVelocityProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/StandardVelocityProvider.java
@@ -81,7 +81,7 @@ public final class StandardVelocityProvider implements VelocityProvider {
     @Override
     public Vector get(Particle particle) {
         Vector velocity = (Vector) particle.getVelocity();
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
         Vector localGuide = (Vector) particle.getLocalGuide();
         Vector globalGuide = (Vector) particle.getGlobalGuide();
 

--- a/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/binary/BinaryMVVelocityProvider.java
+++ b/library/src/main/java/net/sourceforge/cilib/pso/velocityprovider/binary/BinaryMVVelocityProvider.java
@@ -69,8 +69,8 @@ public final class BinaryMVVelocityProvider implements VelocityProvider {
         if ((properties.get(Velocity.V0) == null)
             || (properties.get(Velocity.V1) == null)) {
 
-            particle.getProperties().put(Velocity.V0, particle.getPosition());
-            particle.getProperties().put(Velocity.V1, particle.getPosition());
+            particle.getProperties().put(Velocity.V0, particle.getCandidateSolution());
+            particle.getProperties().put(Velocity.V1, particle.getCandidateSolution());
         }
 
         Vector v0 = (Vector) properties.get(Velocity.V0);
@@ -107,7 +107,7 @@ public final class BinaryMVVelocityProvider implements VelocityProvider {
 
         // return combined velocity
         Vector.Builder combined = Vector.newBuilder();
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
         for (int i = 0; i < particle.getDimension(); i++) {
             if (position.booleanValueOf(i)) {
                 combined.addWithin(v0.doubleValueOf(i), position.boundsOf(i));

--- a/library/src/main/java/net/sourceforge/cilib/util/functions/Particles.java
+++ b/library/src/main/java/net/sourceforge/cilib/util/functions/Particles.java
@@ -19,7 +19,7 @@ public final class Particles {
         return new F<P, Vector>() {
             @Override
             public Vector f(P a) {
-                return (Vector) a.getPosition();
+                return (Vector) a.getCandidateSolution();
             }
         };
     }

--- a/library/src/test/java/net/sourceforge/cilib/clustering/entity/ClusterParticleTest.java
+++ b/library/src/test/java/net/sourceforge/cilib/clustering/entity/ClusterParticleTest.java
@@ -155,7 +155,7 @@ public class ClusterParticleTest {
         holder.add(centroid);
         instance.setCandidateSolution(holder);
 
-        Assert.assertEquals(instance.getPosition(), holder);
+        Assert.assertEquals(instance.getCandidateSolution(), holder);
     }
 
     /**

--- a/library/src/test/java/net/sourceforge/cilib/entity/initialisation/RandomInitialisationStrategyTest.java
+++ b/library/src/test/java/net/sourceforge/cilib/entity/initialisation/RandomInitialisationStrategyTest.java
@@ -34,7 +34,7 @@ public class RandomInitialisationStrategyTest {
         RandomInitialisationStrategy<Particle> strategy = new RandomInitialisationStrategy<Particle>();
         strategy.initialise(EntityType.CANDIDATE_SOLUTION, particle);
 
-        Vector position = (Vector) particle.getPosition();
+        Vector position = (Vector) particle.getCandidateSolution();
 
         for (int i = 0; i < particle.getDimension(); i++) {
             Assert.assertThat(expected.doubleValueOf(i), is(not(equalTo(position.doubleValueOf(i)))));

--- a/library/src/test/java/net/sourceforge/cilib/entity/topologies/VonNeumannTopologyTest.java
+++ b/library/src/test/java/net/sourceforge/cilib/entity/topologies/VonNeumannTopologyTest.java
@@ -183,7 +183,7 @@ public class VonNeumannTopologyTest {
         }
 
         @Override
-        public Vector getPosition() {
+        public Vector getCandidateSolution() {
             throw new UnsupportedOperationException("Mocked object - not allowed");
         }
 

--- a/library/src/test/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/CascadeNetworkExpansionReactionStrategyTest.java
+++ b/library/src/test/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/CascadeNetworkExpansionReactionStrategyTest.java
@@ -62,7 +62,7 @@ public class CascadeNetworkExpansionReactionStrategyTest {
         Assert.assertEquals(5, problem.getNeuralNetwork().getWeights().size());
 
         for (int i = 0; i < Topologies.getBestEntity(pso.getTopology()).getDimension(); ++i) {
-            ((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).set(i, Real.valueOf(0.0));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution()).set(i, Real.valueOf(0.0));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).set(i, Real.valueOf(0.0));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).set(i, Real.valueOf(0.0));
         }
@@ -71,7 +71,7 @@ public class CascadeNetworkExpansionReactionStrategyTest {
         Assert.assertEquals(11, problem.getNeuralNetwork().getWeights().size());
         Assert.assertEquals(Vector.of(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0,
                                       Double.NaN),
-                            (Vector)Topologies.getBestEntity(pso.getTopology()).getPosition());
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getCandidateSolution());
         Assert.assertEquals(Vector.of(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0,
                                       Double.NaN),
                             (Vector)Topologies.getBestEntity(pso.getTopology()).getVelocity());
@@ -80,7 +80,7 @@ public class CascadeNetworkExpansionReactionStrategyTest {
                             (Vector)Topologies.getBestEntity(pso.getTopology()).getBestPosition());
 
         for (int i = 0; i < Topologies.getBestEntity(pso.getTopology()).getDimension(); ++i) {
-            ((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).set(i, Real.valueOf(0.0));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution()).set(i, Real.valueOf(0.0));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).set(i, Real.valueOf(0.0));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).set(i, Real.valueOf(0.0));
         }
@@ -89,7 +89,7 @@ public class CascadeNetworkExpansionReactionStrategyTest {
         Assert.assertEquals(18, problem.getNeuralNetwork().getWeights().size());
         Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
                                       Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN),
-                            (Vector)Topologies.getBestEntity(pso.getTopology()).getPosition());
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getCandidateSolution());
         Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
                                       Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN),
                             (Vector)Topologies.getBestEntity(pso.getTopology()).getVelocity());
@@ -98,7 +98,7 @@ public class CascadeNetworkExpansionReactionStrategyTest {
                             (Vector)Topologies.getBestEntity(pso.getTopology()).getBestPosition());
 
         for (int i = 0; i < Topologies.getBestEntity(pso.getTopology()).getDimension(); ++i) {
-            ((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).set(i, Real.valueOf(0.0));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution()).set(i, Real.valueOf(0.0));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).set(i, Real.valueOf(0.0));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).set(i, Real.valueOf(0.0));
         }
@@ -108,7 +108,7 @@ public class CascadeNetworkExpansionReactionStrategyTest {
         Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                                       0.0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0,
                                       0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN),
-                            (Vector)Topologies.getBestEntity(pso.getTopology()).getPosition());
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getCandidateSolution());
         Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                                       0.0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0,
                                       0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN),
@@ -156,7 +156,7 @@ public class CascadeNetworkExpansionReactionStrategyTest {
         Assert.assertEquals(8, problem.getNeuralNetwork().getWeights().size());
 
         for (int i = 0; i < Topologies.getBestEntity(pso.getTopology()).getDimension(); ++i) {
-            ((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).set(i, Real.valueOf(0.0));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution()).set(i, Real.valueOf(0.0));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).set(i, Real.valueOf(0.0));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).set(i, Real.valueOf(0.0));
         }
@@ -165,7 +165,7 @@ public class CascadeNetworkExpansionReactionStrategyTest {
         Assert.assertEquals(14, problem.getNeuralNetwork().getWeights().size());
         Assert.assertEquals(Vector.of(Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0, 0.0, 0.0, Double.NaN, 0.0,
                                       0.0, 0.0, 0.0, Double.NaN),
-                            (Vector)Topologies.getBestEntity(pso.getTopology()).getPosition());
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getCandidateSolution());
         Assert.assertEquals(Vector.of(Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0, 0.0, 0.0, Double.NaN, 0.0,
                                       0.0, 0.0, 0.0, Double.NaN),
                             (Vector)Topologies.getBestEntity(pso.getTopology()).getVelocity());
@@ -174,7 +174,7 @@ public class CascadeNetworkExpansionReactionStrategyTest {
                             (Vector)Topologies.getBestEntity(pso.getTopology()).getBestPosition());
 
         for (int i = 0; i < Topologies.getBestEntity(pso.getTopology()).getDimension(); ++i) {
-            ((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).set(i, Real.valueOf(0.0));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution()).set(i, Real.valueOf(0.0));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).set(i, Real.valueOf(0.0));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).set(i, Real.valueOf(0.0));
         }
@@ -184,7 +184,7 @@ public class CascadeNetworkExpansionReactionStrategyTest {
         Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0,
                                       0.0, 0.0, 0.0, 0.0, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0,
                                       Double.NaN),
-                            (Vector)Topologies.getBestEntity(pso.getTopology()).getPosition());
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getCandidateSolution());
         Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0,
                                       0.0, 0.0, 0.0, 0.0, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0,
                                       Double.NaN),
@@ -195,7 +195,7 @@ public class CascadeNetworkExpansionReactionStrategyTest {
                             (Vector)Topologies.getBestEntity(pso.getTopology()).getBestPosition());
 
         for (int i = 0; i < Topologies.getBestEntity(pso.getTopology()).getDimension(); ++i) {
-            ((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).set(i, Real.valueOf(0.0));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution()).set(i, Real.valueOf(0.0));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).set(i, Real.valueOf(0.0));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).set(i, Real.valueOf(0.0));
         }
@@ -205,7 +205,7 @@ public class CascadeNetworkExpansionReactionStrategyTest {
         Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN,
                                       Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0,
                                       0.0, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN),
-                            (Vector)Topologies.getBestEntity(pso.getTopology()).getPosition());
+                            (Vector)Topologies.getBestEntity(pso.getTopology()).getCandidateSolution());
         Assert.assertEquals(Vector.of(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN,
                                       Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0,
                                       0.0, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.NaN),

--- a/library/src/test/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/InitialiseNaNElementsReactionStrategyTest.java
+++ b/library/src/test/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/InitialiseNaNElementsReactionStrategyTest.java
@@ -56,7 +56,7 @@ public class InitialiseNaNElementsReactionStrategyTest {
         Assert.assertEquals(5, problem.getNeuralNetwork().getWeights().size());
 
         for (int i = 0; i < Topologies.getBestEntity(pso.getTopology()).getDimension(); ++i) {
-            ((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).set(i, Real.valueOf(0.0));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution()).set(i, Real.valueOf(0.0));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).set(i, Real.valueOf(0.0));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).set(i, Real.valueOf(0.0));
         }
@@ -65,7 +65,7 @@ public class InitialiseNaNElementsReactionStrategyTest {
         Assert.assertEquals(11, problem.getNeuralNetwork().getWeights().size());
         Assert.assertEquals(Vector.of(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0,
                                       Double.NaN),
-                            (Vector) Topologies.getBestEntity(pso.getTopology()).getPosition());
+                            (Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution());
         Assert.assertEquals(Vector.of(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0.0, 0.0, 0.0, 0.0, 0.0,
                                       Double.NaN),
                             (Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity());
@@ -76,7 +76,7 @@ public class InitialiseNaNElementsReactionStrategyTest {
         secondReaction.performReaction(pso);
         Assert.assertEquals(11, ((Vector) pso.getBestSolution().getPosition()).size());
         Assert.assertEquals(11, problem.getNeuralNetwork().getWeights().size());
-        Vector position = (Vector) Topologies.getBestEntity(pso.getTopology()).getPosition();
+        Vector position = (Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution();
         for (int curElement = 0; curElement < position.size(); ++curElement) {
             Assert.assertTrue(!Double.isNaN(position.doubleValueOf(curElement)));
         }

--- a/library/src/test/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/ReinitialiseCascadeNetworkOutputWeightsReactionStrategyTest.java
+++ b/library/src/test/java/net/sourceforge/cilib/pso/dynamic/responsestrategies/ReinitialiseCascadeNetworkOutputWeightsReactionStrategyTest.java
@@ -58,7 +58,7 @@ public class ReinitialiseCascadeNetworkOutputWeightsReactionStrategyTest {
         Assert.assertEquals(26, problem.getNeuralNetwork().getWeights().size());
 
         for (int i = 0; i < Topologies.getBestEntity(pso.getTopology()).getDimension(); ++i) {
-            ((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).set(i, Real.valueOf(Double.NaN));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution()).set(i, Real.valueOf(Double.NaN));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).set(i, Real.valueOf(Double.NaN));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).set(i, Real.valueOf(Double.NaN));
         }
@@ -68,13 +68,13 @@ public class ReinitialiseCascadeNetworkOutputWeightsReactionStrategyTest {
         Assert.assertEquals(26, problem.getNeuralNetwork().getWeights().size());
 
         for (int i = 0; i < 18; ++i) {
-            Assert.assertTrue(Double.isNaN(((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).doubleValueOf(i)));
+            Assert.assertTrue(Double.isNaN(((Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution()).doubleValueOf(i)));
             Assert.assertTrue(Double.isNaN(((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).doubleValueOf(i)));
             Assert.assertTrue(Double.isNaN(((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).doubleValueOf(i)));
         }
 
         for (int i = 18; i < 26; ++i) {
-            Assert.assertTrue(!Double.isNaN(((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).doubleValueOf(i)));
+            Assert.assertTrue(!Double.isNaN(((Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution()).doubleValueOf(i)));
             Assert.assertTrue(((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).doubleValueOf(i) == 0.0);
             Assert.assertTrue(Double.isNaN(((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).doubleValueOf(i)));
         }
@@ -113,7 +113,7 @@ public class ReinitialiseCascadeNetworkOutputWeightsReactionStrategyTest {
         Assert.assertEquals(25, problem.getNeuralNetwork().getWeights().size());
 
         for (int i = 0; i < Topologies.getBestEntity(pso.getTopology()).getDimension(); ++i) {
-            ((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).set(i, Real.valueOf(Double.NaN));
+            ((Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution()).set(i, Real.valueOf(Double.NaN));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).set(i, Real.valueOf(Double.NaN));
             ((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).set(i, Real.valueOf(Double.NaN));
         }
@@ -123,13 +123,13 @@ public class ReinitialiseCascadeNetworkOutputWeightsReactionStrategyTest {
         Assert.assertEquals(25, problem.getNeuralNetwork().getWeights().size());
 
         for (int i = 0; i < 17; ++i) {
-            Assert.assertTrue(Double.isNaN(((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).doubleValueOf(i)));
+            Assert.assertTrue(Double.isNaN(((Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution()).doubleValueOf(i)));
             Assert.assertTrue(Double.isNaN(((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).doubleValueOf(i)));
             Assert.assertTrue(Double.isNaN(((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).doubleValueOf(i)));
         }
 
         for (int i = 17; i < 25; ++i) {
-            Assert.assertTrue(!Double.isNaN(((Vector) Topologies.getBestEntity(pso.getTopology()).getPosition()).doubleValueOf(i)));
+            Assert.assertTrue(!Double.isNaN(((Vector) Topologies.getBestEntity(pso.getTopology()).getCandidateSolution()).doubleValueOf(i)));
             Assert.assertTrue(((Vector) Topologies.getBestEntity(pso.getTopology()).getVelocity()).doubleValueOf(i) == 0.0);
             Assert.assertTrue(Double.isNaN(((Vector) Topologies.getBestEntity(pso.getTopology()).getBestPosition()).doubleValueOf(i)));
         }

--- a/library/src/test/java/net/sourceforge/cilib/pso/pbestupdate/BoundedPersonalBestUpdateStrategyTest.java
+++ b/library/src/test/java/net/sourceforge/cilib/pso/pbestupdate/BoundedPersonalBestUpdateStrategyTest.java
@@ -39,7 +39,7 @@ public class BoundedPersonalBestUpdateStrategyTest {
         strategy.updatePersonalBest(particle);
 
         Assert.assertThat(particle.getBestFitness(), is(particle.getFitness()));
-        Assert.assertThat(particle.getBestPosition(), is(particle.getPosition()));
+        Assert.assertThat(particle.getBestPosition(), is(particle.getCandidateSolution()));
     }
 
     @Test

--- a/library/src/test/java/net/sourceforge/cilib/pso/pbestupdate/StandardPersonalBestUpdateStrategyTest.java
+++ b/library/src/test/java/net/sourceforge/cilib/pso/pbestupdate/StandardPersonalBestUpdateStrategyTest.java
@@ -42,7 +42,7 @@ public class StandardPersonalBestUpdateStrategyTest {
         strategy.updatePersonalBest(particle);
 
         Assert.assertThat(particle.getBestFitness(), is(particle.getFitness()));
-        Assert.assertThat(particle.getBestPosition(), is(particle.getPosition()));
+        Assert.assertThat(particle.getBestPosition(), is(particle.getCandidateSolution()));
         Assert.assertEquals(((Int)particle.getProperties().get(EntityType.Particle.Count.PBEST_STAGNATION_COUNTER)).intValue(), 0);
     }
 
@@ -65,7 +65,7 @@ public class StandardPersonalBestUpdateStrategyTest {
         strategy.updatePersonalBest(particle);
 
         Assert.assertThat(particle.getBestFitness(), is(not(particle.getFitness())));
-        Assert.assertThat(particle.getBestPosition(), is(not(particle.getPosition())));
+        Assert.assertThat(particle.getBestPosition(), is(not(particle.getCandidateSolution())));
         Assert.assertEquals(((Int)particle.getProperties().get(EntityType.Particle.Count.PBEST_STAGNATION_COUNTER)).intValue(), 1);
     }
 }


### PR DESCRIPTION
Both methods accessed the same information in pretty much the same
way. So only one is necessary. This is a step towards consolidating
all of the entities into one entity.

In some cases, it is required that getCandidateSolution returns a
Vector. The necessary cast has been added where ever I noticed such
situations.
