### PR TITLE
F-Race Fixes

### DIFF
--- a/library/src/main/java/net/sourceforge/cilib/tuning/FRaceIterationStrategy.java
+++ b/library/src/main/java/net/sourceforge/cilib/tuning/FRaceIterationStrategy.java
@@ -63,8 +63,7 @@ public class FRaceIterationStrategy extends AbstractIterationStrategy<TuningAlgo
             }
         }));
         
-        // (+1 because iterations start at 0)
-        if (alg.getIterations() + 1 >= minProblems.getParameter() && parameterList.length() > 1) {
+        if (results.length() >= minProblems.getParameter() && parameterList.length() > 1) {
             List<List<Double>> data = results
                 .map(List.<OptimisationSolution,Double>map_().f(getFitness()
                     .andThen(getValue())
@@ -83,7 +82,7 @@ public class FRaceIterationStrategy extends AbstractIterationStrategy<TuningAlgo
                             return indexes.map(flip(Utils.<OptimisationSolution>index()).f(a));
                         }
                     });
-                } else {
+                } else if (indexes.isNotEmpty() && indexes.length() < minSolutions.getParameter()) {
                     final List<List<Double>> ranks = iterableList(data)
                         .map(Stats.rank.andThen(Utils.<Double,Iterable>iterableList()));
                     final List<Integer> newIndexes = ranks.foldLeft(Utils.<Double>pairwise(add), replicate(data.head().length(), 0.0))


### PR DESCRIPTION
-F-Race no longer discards all parameter configurations if the post-hoc
test fails to determine where the statistical difference lies

-F-Race now compares minProblems to the length of the results list
(not the iteration count) to determine when statistical tests should
be performed

Signed-off-by: Bennie Leonard bennie.leonard@gmail.com
