### PR TITLE
Angle Modulation Fixes

### DIFF
--- a/library/src/main/java/net/sourceforge/cilib/functions/discrete/Onemax.java
+++ b/library/src/main/java/net/sourceforge/cilib/functions/discrete/Onemax.java
@@ -25,7 +25,9 @@ public class Onemax extends ContinuousFunction {
         double result = 0.0;
 
         for (int i = 0; i < input.size(); i++) {
-            result += input.doubleValueOf(i);
+            if(input.booleanValueOf(i)) {
+                result++;
+            }
         }
 
         return result;

--- a/library/src/main/java/net/sourceforge/cilib/problem/AngleModulationProblem.java
+++ b/library/src/main/java/net/sourceforge/cilib/problem/AngleModulationProblem.java
@@ -48,7 +48,10 @@ public class AngleModulationProblem extends AbstractProblem {
         
         for (int i = 0; i < bits.length(); i += bitsPerDimension) {
             double tmp = valueOf(bits, i, i + bitsPerDimension);
-            tmp = transform(tmp);
+            
+            if (bitsPerDimension > 1) {
+                tmp = transform(tmp);
+            }
 
             vector.add(tmp);
         }


### PR DESCRIPTION
-AngleModulationProblem no longe converts binary solutions to erroneous double vectors
-OneMax now expects a binary input vector

Signed-off-by: Bennie Leonard bennie.leonard@gmail.com
