### PR TITLE
NN Output Activations Measurement

### DIFF
--- a/library/src/main/java/net/sourceforge/cilib/measurement/single/NNOutputActivations.java
+++ b/library/src/main/java/net/sourceforge/cilib/measurement/single/NNOutputActivations.java
@@ -1,0 +1,47 @@
+/**           __  __
+ *    _____ _/ /_/ /_    Computational Intelligence Library (CIlib)
+ *   / ___/ / / / __ \   (c) CIRG @ UP
+ *  / /__/ / / / /_/ /   http://cilib.net
+ *  \___/_/_/_/_.___/
+ */
+package net.sourceforge.cilib.measurement.single;
+
+import java.util.List;
+import net.sourceforge.cilib.algorithm.Algorithm;
+import net.sourceforge.cilib.measurement.Measurement;
+import net.sourceforge.cilib.nn.architecture.Layer;
+import net.sourceforge.cilib.problem.nn.NNTrainingProblem;
+import net.sourceforge.cilib.type.types.Int;
+import net.sourceforge.cilib.type.types.StringType;
+import net.sourceforge.cilib.type.types.container.Vector;
+
+/**
+ * Gets the activations produced by die output layer of NN.
+ */
+public class NNOutputActivations implements Measurement {
+
+    /**
+     * {@inheritDoc }
+     */
+    @Override
+    public NNOutputActivations getClone() {
+        return new NNOutputActivations();
+    }
+
+    /**
+     * {@inheritDoc }
+     */
+    @Override
+    public StringType getValue(Algorithm algorithm) {
+        NNTrainingProblem problem = (NNTrainingProblem) algorithm.getOptimisationProblem();
+        
+        //Get output layer
+        List layers = problem.getNeuralNetwork().getArchitecture().getLayers();
+        int size = layers.size();
+        Layer output_layer = (Layer)layers.get(size - 1);
+        
+        //Get activations
+        Vector activations = output_layer.getActivations();
+        return new StringType(activations.toString());
+    }
+}


### PR DESCRIPTION
# NNOutputActivations
## Description:

Added the NNOutputActivations measurement to be able to extract the
resulting predictions/classifications made by the NN after each
iteration. An example of where this is useful, is where analysis on the
actual predictions of a given NN has to be made for an experiment such
as Time Series Data Analysis
## Example of outcome:

Prerequisites:
- Time Series Data Set, exchange rates over a few years
- FFNN Trained with ChargedPSO (Period: 1)
- Input:
  - year: scaled (year-LB)/(UB-LB) where LB = 1965 and UB = 2000
  - month: scaled to month/12
  - for training set: Exchange rate is provided
- Output:
  - Predicted exchange rate, scaled back from (0..1) to (0..140)
- **The NN in the example was by no means optimised i.t.o. parameter selection and is just an example of how the outcome can be used.**

<div class="pull-left">
<img src="http://i61.tinypic.com/2ey80tx.png" title="Time Series Data Plot" width="450px"  />
</div>

<div class="pull-left">
<img src="http://i61.tinypic.com/xt9mp.png" title="MSEGeneralisationError" width="450px" />
</div>

## Simulation (Added measurement):

``` xml
<measurements id="nnoutput" class="simulator.MeasurementSuite" resolution="1">
    <addMeasurement class="measurement.single.NNOutputActivations"/>
</measurements>
```
