### PR TITLE
Pretty printer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -356,6 +356,7 @@ lazy val io = project
         "com.sksamuel.avro4s" %% "avro4s-core" % avro4sVersion,
         "org.apache.parquet" % "parquet-avro" % "1.9.0",
         "org.apache.hadoop" % "hadoop-client" % "2.7.3",
-        "org.scalaz.stream" %% "scalaz-stream" % scalazStreamVersion
+        "org.scalaz.stream" %% "scalaz-stream" % scalazStreamVersion,
+        "org.typelevel" %% "paiges-core" % "0.2.1"
       )
     ))

--- a/example/src/main/scala/cilib/example/GA.scala
+++ b/example/src/main/scala/cilib/example/GA.scala
@@ -12,8 +12,6 @@ import spire.implicits._
 import spire.math.Interval
 
 import cilib.ga._
-import cilib.io.PrettyPrinter
-import PrettyPrinter._
 import Lenses._
 
 object GAExample extends SafeApp {
@@ -69,9 +67,6 @@ object GAExample extends SafeApp {
             .map(_.take(20).toNel.getOrElse(sys.error("asdas"))))
 
   // Our IO[Unit] that runs at the end of the world
-  override val runc: IO[Unit] = {
-      val x = exec.Runner.repeat(1000, cullingGA, swarm).run(env).run(RNG.fromTime)
-      x
-      putStrLn(.toString)
-  }
+  override val runc: IO[Unit] =
+    putStrLn(exec.Runner.repeat(1000, cullingGA, swarm).run(env).run(RNG.fromTime).toString)
 }

--- a/example/src/main/scala/cilib/example/GA.scala
+++ b/example/src/main/scala/cilib/example/GA.scala
@@ -64,27 +64,26 @@ object GAExample extends SafeApp {
         r =>
           Step
             .withCompare(o => r.sortWith((x, y) => Comparison.fitter(x.pos, y.pos).apply(o)))
-              .map(_.take(20).toNel.getOrElse(sys.error("asdas"))))
+            .map(_.take(20).toNel.getOrElse(sys.error("asdas"))))
 
-    val problemStream = Runner.staticProblem("spherical", env.eval)
+  val problemStream = Runner.staticProblem("spherical", env.eval)
 
-    // Our IO[Unit] that runs at the end of the world
+  // Our IO[Unit] that runs at the end of the world
   override val runc: IO[Unit] = {
-      val process = Runner.foldStep(
-          env,
-          RNG.fromTime,
-          swarm,
-          Runner.staticAlgorithm("GA", cullingGA),
-          problemStream,
-          (x: NonEmptyList[Ind], _: Eval[NonEmptyList, Double]) =>
-              RVar.pure(x)
-      )
+    val process = Runner.foldStep(
+      env,
+      RNG.fromTime,
+      swarm,
+      Runner.staticAlgorithm("GA", cullingGA),
+      problemStream,
+      (x: NonEmptyList[Ind], _: Eval[NonEmptyList, Double]) => RVar.pure(x)
+    )
 
-      val result = process.take(1000).runLast.unsafePerformSync match {
-          case Some(x) => PrettyPrinter(x).render(1000)
-          case None => "Error"
-      }
+    val result = process.take(1000).runLast.unsafePerformSync match {
+      case Some(x) => PrettyPrinter(x).render(1000)
+      case None    => "Error"
+    }
 
-      putStrLn(result)
+    putStrLn(result)
   }
 }

--- a/example/src/main/scala/cilib/example/GA.scala
+++ b/example/src/main/scala/cilib/example/GA.scala
@@ -12,6 +12,8 @@ import spire.implicits._
 import spire.math.Interval
 
 import cilib.ga._
+import cilib.io.PrettyPrinter
+import PrettyPrinter._
 import Lenses._
 
 object GAExample extends SafeApp {
@@ -67,6 +69,9 @@ object GAExample extends SafeApp {
             .map(_.take(20).toNel.getOrElse(sys.error("asdas"))))
 
   // Our IO[Unit] that runs at the end of the world
-  override val runc: IO[Unit] =
-    putStrLn(exec.Runner.repeat(1000, cullingGA, swarm).run(env).run(RNG.fromTime).toString)
+  override val runc: IO[Unit] = {
+      val x = exec.Runner.repeat(1000, cullingGA, swarm).run(env).run(RNG.fromTime)
+      x
+      putStrLn(.toString)
+  }
 }

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -4,9 +4,9 @@ package example
 import cilib.pso._
 import cilib.pso.Defaults._
 import cilib.exec._
-
+import cilib.io.PrettyPrinter
+import PrettyPrinter._
 import eu.timepit.refined.auto._
-
 import scalaz._
 import scalaz.effect._
 import scalaz.effect.IO.putStrLn
@@ -44,6 +44,11 @@ object GBestPSO extends SafeApp {
                 RVar.pure(x)
         )
 
-        putStrLn(t.take(1000).runLast.unsafePerformSync.toString)
+        val result = t.take(1000).runLast.unsafePerformSync match {
+            case Some(x) => PrettyPrinter(x).render(1000)
+            case None => "Error"
+        }
+
+        putStrLn(result)
     }
 }

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -14,41 +14,41 @@ import spire.implicits._
 import spire.math.Interval
 
 object GBestPSO extends SafeApp {
-    val bounds = Interval(-5.12, 5.12) ^ 30
-    val env =
-        Environment(cmp = Comparison.dominance(Min),
-            eval =
-                Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+  val bounds = Interval(-5.12, 5.12) ^ 30
+  val env =
+    Environment(cmp = Comparison.dominance(Min),
+                eval =
+                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
-    // Define a normal GBest PSO and run it for a single iteration
-    val cognitive = Guide.pbest[Mem[Double], Double]
-    val social = Guide.gbest[Mem[Double]]
-    val gbestPSO = gbest(0.729844, 1.496180, 1.496180, cognitive, social)
+  // Define a normal GBest PSO and run it for a single iteration
+  val cognitive = Guide.pbest[Mem[Double], Double]
+  val social = Guide.gbest[Mem[Double]]
+  val gbestPSO = gbest(0.729844, 1.496180, 1.496180, cognitive, social)
 
-    // RVar
-    val swarm =
-        Position.createCollection(PSO.createParticle(x => Entity(Mem(x, x.zeroed), x)))(bounds, 20)
-    val iter = Iteration.sync(gbestPSO)
+  // RVar
+  val swarm =
+    Position.createCollection(PSO.createParticle(x => Entity(Mem(x, x.zeroed), x)))(bounds, 20)
+  val iter = Iteration.sync(gbestPSO)
 
-    val problemStream = Runner.staticProblem("spherical", env.eval)
+  val problemStream = Runner.staticProblem("spherical", env.eval)
 
-    // Our IO[Unit] that runs the algorithm, at the end of the world
-    override val runc: IO[Unit] = {
-        val process = Runner.foldStep(
-            env,
-            RNG.fromTime,
-            swarm,
-            Runner.staticAlgorithm("gbestPSO", iter),
-            problemStream,
-            (x: NonEmptyList[Particle[Mem[Double], Double]], _: Eval[NonEmptyList, Double]) =>
-                RVar.pure(x)
-        )
+  // Our IO[Unit] that runs the algorithm, at the end of the world
+  override val runc: IO[Unit] = {
+    val process = Runner.foldStep(
+      env,
+      RNG.fromTime,
+      swarm,
+      Runner.staticAlgorithm("gbestPSO", iter),
+      problemStream,
+      (x: NonEmptyList[Particle[Mem[Double], Double]], _: Eval[NonEmptyList, Double]) =>
+        RVar.pure(x)
+    )
 
-        val result = process.take(1000).runLast.unsafePerformSync match {
-            case Some(x) => PrettyPrinter(x).render(1000)
-            case None => "Error"
-        }
-
-        putStrLn(result)
+    val result = process.take(1000).runLast.unsafePerformSync match {
+      case Some(x) => PrettyPrinter(x).render(1000)
+      case None    => "Error"
     }
+
+    putStrLn(result)
+  }
 }

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -34,7 +34,7 @@ object GBestPSO extends SafeApp {
 
     // Our IO[Unit] that runs the algorithm, at the end of the world
     override val runc: IO[Unit] = {
-        val process = Runner.foldStep(
+        val t = Runner.foldStep(
             env,
             RNG.fromTime,
             swarm,
@@ -44,7 +44,7 @@ object GBestPSO extends SafeApp {
                 RVar.pure(x)
         )
 
-        val result = process.take(1000).runLast.unsafePerformSync match {
+        val result = t.take(1000).runLast.unsafePerformSync match {
             case Some(x) => PrettyPrinter(x).render(1000)
             case None => "Error"
         }

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -14,36 +14,36 @@ import spire.implicits._
 import spire.math.Interval
 
 object GBestPSO extends SafeApp {
-  val bounds = Interval(-5.12, 5.12) ^ 30
-  val env =
-    Environment(cmp = Comparison.dominance(Min),
-                eval =
-                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+    val bounds = Interval(-5.12, 5.12) ^ 30
+    val env =
+        Environment(cmp = Comparison.dominance(Min),
+            eval =
+                Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
-  // Define a normal GBest PSO and run it for a single iteration
-  val cognitive = Guide.pbest[Mem[Double], Double]
-  val social = Guide.gbest[Mem[Double]]
-  val gbestPSO = gbest(0.729844, 1.496180, 1.496180, cognitive, social)
+    // Define a normal GBest PSO and run it for a single iteration
+    val cognitive = Guide.pbest[Mem[Double], Double]
+    val social = Guide.gbest[Mem[Double]]
+    val gbestPSO = gbest(0.729844, 1.496180, 1.496180, cognitive, social)
 
-  // RVar
-  val swarm =
-    Position.createCollection(PSO.createParticle(x => Entity(Mem(x, x.zeroed), x)))(bounds, 20)
-  val iter = Iteration.sync(gbestPSO)
+    // RVar
+    val swarm =
+        Position.createCollection(PSO.createParticle(x => Entity(Mem(x, x.zeroed), x)))(bounds, 20)
+    val iter = Iteration.sync(gbestPSO)
 
-  val problemStream = Runner.staticProblem("spherical", env.eval)
+    val problemStream = Runner.staticProblem("spherical", env.eval)
 
-  // Our IO[Unit] that runs the algorithm, at the end of the world
-  override val runc: IO[Unit] = {
-    val t = Runner.foldStep(
-      env,
-      RNG.fromTime,
-      swarm,
-      Runner.staticAlgorithm("gbestPSO", iter),
-      problemStream,
-      (x: NonEmptyList[Particle[Mem[Double], Double]], _: Eval[NonEmptyList, Double]) =>
-        RVar.pure(x)
-    )
+    // Our IO[Unit] that runs the algorithm, at the end of the world
+    override val runc: IO[Unit] = {
+        val t = Runner.foldStep(
+            env,
+            RNG.fromTime,
+            swarm,
+            Runner.staticAlgorithm("gbestPSO", iter),
+            problemStream,
+            (x: NonEmptyList[Particle[Mem[Double], Double]], _: Eval[NonEmptyList, Double]) =>
+                RVar.pure(x)
+        )
 
-    putStrLn(t.take(1000).runLast.unsafePerformSync.toString)
-  }
+        putStrLn(t.take(1000).runLast.unsafePerformSync.toString)
+    }
 }

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -34,7 +34,7 @@ object GBestPSO extends SafeApp {
 
     // Our IO[Unit] that runs the algorithm, at the end of the world
     override val runc: IO[Unit] = {
-        val t = Runner.foldStep(
+        val process = Runner.foldStep(
             env,
             RNG.fromTime,
             swarm,
@@ -44,7 +44,7 @@ object GBestPSO extends SafeApp {
                 RVar.pure(x)
         )
 
-        val result = t.take(1000).runLast.unsafePerformSync match {
+        val result = process.take(1000).runLast.unsafePerformSync match {
             case Some(x) => PrettyPrinter(x).render(1000)
             case None => "Error"
         }

--- a/io/src/main/scala/PrettyPrinter.scala
+++ b/io/src/main/scala/PrettyPrinter.scala
@@ -4,29 +4,41 @@ package io
 import org.typelevel.paiges._
 import scalaz._
 import Scalaz._
+import spire.math.Interval
+
+sealed trait PrettyPrinter[A] {
+    def toDoc(x: A): Doc
+}
 
 object PrettyPrinter {
 
-    implicit class positionPrinterOps(p: Position[Double]){
-        def prettyPrint: Doc = {
-            val pos = Doc.text("Position: ") +
-                Doc.intercalate(Doc.text(", "), p.pos.toList.map(x => Doc.text(x.toString))) +
-                Doc.line
+    def apply[A](x: A)(implicit prettyPrinter: PrettyPrinter[A]): Doc = prettyPrinter.toDoc(x)
 
-            val bounds = if(p.boundary.toList.forall(_ == p.boundary.head)) {
-                Doc.text("All points in the position share the same bounds of " + p.boundary.head.toString())
-            } else {
-                Doc.text("Bounds: ") +
-                    Doc.intercalate(Doc.text(", "), p.boundary.toList.map(x => Doc.text(x.toString()))) +
+    implicit val boundsPrettyPrinter: PrettyPrinter[NonEmptyList[Interval[Double]]] =
+        new PrettyPrinter[NonEmptyList[Interval[Double]]] {
+            def toDoc(bounds: NonEmptyList[Interval[Double]]): Doc =
+                Doc.intercalate(Doc.paragraph(", "), bounds.toList.map(x => Doc.paragraph(x.toString()))) +
                     Doc.line
-            }
-
-            val solution = Lenses._singleFitness[Double].composePrism(Lenses._feasible).headOption(p) match {
-                    case None        => Doc.empty
-                    case Some(value) => Doc.text("Solution: " + value.toString)
-                }
-
         }
-    }
+
+    implicit val nelPrettyPrinter: PrettyPrinter[NonEmptyList[Double]] =
+        new PrettyPrinter[NonEmptyList[Double]] {
+            def toDoc(bounds: NonEmptyList[Double]): Doc =
+                Doc.intercalate(Doc.paragraph(", "), bounds.toList.map(x => Doc.paragraph(x.toString()))) +
+                    Doc.line
+        }
+
+    implicit val positionPrettyPrinter: PrettyPrinter[Position[Double]] =
+        new PrettyPrinter[Position[Double]] {
+            def toDoc(x: Position[Double]): Doc =
+                Doc.paragraph("Position: ") + nelPrettyPrinter.toDoc(x.pos) + Doc.paragraph("Bounds: ") +
+                    boundsPrettyPrinter.toDoc(x.boundary)
+        }
 
 }
+
+val rng = RNG.init(12L)
+val bounds = Interval(-10.0, 10.0) ^ 3
+val point = Position.createPosition(bounds).eval(rng)
+
+PrettyPrinter(point).render(80)

--- a/io/src/main/scala/PrettyPrinter.scala
+++ b/io/src/main/scala/PrettyPrinter.scala
@@ -1,44 +1,86 @@
 package cilib
 package io
 
+import cilib.exec.Progress
 import org.typelevel.paiges._
 import scalaz._
 import Scalaz._
 import spire.math.Interval
 
-sealed trait PrettyPrinter[A] {
+@annotation.implicitNotFound(
+    """
+EncodeDoc derivation error for type: ${A}
+Not all members of the type have instances of EncodeDoc defined, or in
+scope. It is recommended to examine the fields of the type and then to
+define an instance of EncodeDoc for the any custom parameter type.""")
+sealed trait EncodeDoc[A] {
     def toDoc(x: A): Doc
 }
 
 object PrettyPrinter {
 
-    def apply[A](x: A)(implicit prettyPrinter: PrettyPrinter[A]): Doc = prettyPrinter.toDoc(x)
+    def apply[A](a: A)(implicit docEncoder: EncodeDoc[A]) =
+        docEncoder.toDoc(a)
 
-    implicit val boundsPrettyPrinter: PrettyPrinter[NonEmptyList[Interval[Double]]] =
-        new PrettyPrinter[NonEmptyList[Interval[Double]]] {
-            def toDoc(bounds: NonEmptyList[Interval[Double]]): Doc =
-                Doc.intercalate(Doc.paragraph(", "), bounds.toList.map(x => Doc.paragraph(x.toString()))) +
-                    Doc.line
+    def createEncoder[A](f: A => Doc) =
+        new EncodeDoc[A] {
+            override def toDoc(x: A): Doc = f(x)
         }
 
-    implicit val nelPrettyPrinter: PrettyPrinter[NonEmptyList[Double]] =
-        new PrettyPrinter[NonEmptyList[Double]] {
-            def toDoc(bounds: NonEmptyList[Double]): Doc =
-                Doc.intercalate(Doc.paragraph(", "), bounds.toList.map(x => Doc.paragraph(x.toString()))) +
-                    Doc.line
-        }
+    // Method for creating docs based on non empty lists
+    private def nelEncoder[A](x: NonEmptyList[A])(implicit docEncoder: EncodeDoc[A]) =
+        Doc.intercalate(Doc.paragraph(", "), x.toList.map(docEncoder.toDoc))
 
-    implicit val positionPrettyPrinter: PrettyPrinter[Position[Double]] =
-        new PrettyPrinter[Position[Double]] {
-            def toDoc(x: Position[Double]): Doc =
-                Doc.paragraph("Position: ") + nelPrettyPrinter.toDoc(x.pos) + Doc.paragraph("Bounds: ") +
-                    boundsPrettyPrinter.toDoc(x.boundary)
-        }
+    // Encoders for basic types
+    implicit val booleanEncodeDoc = createEncoder[Boolean](x => Doc.paragraph(x.toString))
+    implicit val byteEncodeDoc = createEncoder[Byte](x => Doc.paragraph(x.toString))
+    implicit val shortEncodeDoc = createEncoder[Short](x => Doc.paragraph(x.toString))
+    implicit val intEncodeDoc = createEncoder[Int](x => Doc.paragraph(x.toString))
+    implicit val longEncodeDoc = createEncoder[Long](x => Doc.paragraph(x.toString))
+    implicit val floatEncodeDoc = createEncoder[Float](x => Doc.paragraph(x.toString))
+    implicit val doubleEncodeDoc = createEncoder[Double](x => Doc.paragraph(x.toString))
+    implicit val stringEncodeDoc = createEncoder[String](Doc.paragraph)
+
+    // Opinionated implicicts for common types within CIlib
+    implicit val intervalEncodeDoc = createEncoder[Interval[Double]](x => Doc.paragraph(x.toString))
+
+    implicit val memEncoder = createEncoder[Mem[Double]](x => {
+        val feasibleOptic = Lenses._singleFitness[Double].composePrism(Lenses._feasible)
+        Doc.paragraph("Personal Best Position: ") + nelEncoder(x.b.pos) + Doc.line +
+            Doc.paragraph("Personal Best Bounds: ") + nelEncoder(x.b.boundary) + Doc.line +
+            Doc.paragraph("Personal Best Solution: ") + Doc.paragraph(feasibleOptic.headOption(x.b).getOrElse("Infeasible").toString) +
+            Doc.line + Doc.paragraph("Velocity: ") + nelEncoder(x.v.pos)
+    })
+
+    implicit val positionEncodeDoc = createEncoder[Position[Double]](x => {
+        val feasibleOptic = Lenses._singleFitness[Double].composePrism(Lenses._feasible)
+        Doc.paragraph("Position: ") + nelEncoder(x.pos) + Doc.line +
+            Doc.paragraph("Bounds: ") + nelEncoder(x.boundary) + Doc.line +
+            Doc.paragraph("Solution: ") + Doc.paragraph(feasibleOptic.headOption(x).getOrElse("Infeasible").toString)
+    })
+
+    implicit val stdEntityEcodeDoc = createEncoder[Entity[Mem[Double], Double]](x =>
+        Doc.paragraph("Entity") + Doc.line +
+            positionEncodeDoc.toDoc(x.pos) + Doc.line +
+            memEncoder.toDoc(x.state) + Doc.line
+    )
+
+    implicit val nelStdEntityEcodeDoc = createEncoder[NonEmptyList[Entity[Mem[Double], Double]]](x =>
+        Doc.intercalate(Doc.line, x.zipWithIndex.toList map {
+            case (entity: Entity[Mem[Double], Double], index: Int) =>
+                Doc.paragraph(s"Entity ${index + 1}") + Doc.line +
+                    positionEncodeDoc.toDoc(entity.pos) + Doc.line +
+                    memEncoder.toDoc(entity.state) + Doc.line
+        })
+    )
+
+    implicit val progressEcodeDoc = createEncoder[Progress[NonEmptyList[Entity[Mem[Double], Double]]]](x =>
+        Doc.paragraph(s"Algorithm: ${x.algorithm}") + Doc.line +
+            Doc.paragraph(s"Problem: ${x.problem}") + Doc.line +
+            Doc.paragraph(s"Seed Value: ${x.seed}") + Doc.line +
+            Doc.paragraph(s"Iterations: ${x.iteration}") + Doc.line +
+            Doc.paragraph(s"Environment: ${x.env}") + Doc.line + Doc.line +
+            nelStdEntityEcodeDoc.toDoc(x.value)
+    )
 
 }
-
-val rng = RNG.init(12L)
-val bounds = Interval(-10.0, 10.0) ^ 3
-val point = Position.createPosition(bounds).eval(rng)
-
-PrettyPrinter(point).render(80)

--- a/io/src/main/scala/PrettyPrinter.scala
+++ b/io/src/main/scala/PrettyPrinter.scala
@@ -59,13 +59,13 @@ object PrettyPrinter {
             Doc.paragraph("Solution: ") + Doc.paragraph(feasibleOptic.headOption(x).getOrElse("Infeasible").toString)
     })
 
-    implicit val stdEntityEcodeDoc = createEncoder[Entity[Mem[Double], Double]](x =>
+    implicit val particleEcodeDoc = createEncoder[Entity[Mem[Double], Double]](x =>
         Doc.paragraph("Entity") + Doc.line +
             positionEncodeDoc.toDoc(x.pos) + Doc.line +
             memEncoder.toDoc(x.state) + Doc.line
     )
 
-    implicit val nelStdEntityEcodeDoc = createEncoder[NonEmptyList[Entity[Mem[Double], Double]]](x =>
+    implicit val nelParticleEcodeDoc = createEncoder[NonEmptyList[Entity[Mem[Double], Double]]](x =>
         Doc.intercalate(Doc.line, x.zipWithIndex.toList map {
             case (entity: Entity[Mem[Double], Double], index: Int) =>
                 Doc.paragraph(s"Entity ${index + 1}") + Doc.line +
@@ -74,13 +74,35 @@ object PrettyPrinter {
         })
     )
 
-    implicit val progressEcodeDoc = createEncoder[Progress[NonEmptyList[Entity[Mem[Double], Double]]]](x =>
+    implicit val progressParticleEcodeDoc = createEncoder[Progress[NonEmptyList[Entity[Mem[Double], Double]]]](x =>
         Doc.paragraph(s"Algorithm: ${x.algorithm}") + Doc.line +
             Doc.paragraph(s"Problem: ${x.problem}") + Doc.line +
             Doc.paragraph(s"Seed Value: ${x.seed}") + Doc.line +
             Doc.paragraph(s"Iterations: ${x.iteration}") + Doc.line +
             Doc.paragraph(s"Environment: ${x.env}") + Doc.line + Doc.line +
-            nelStdEntityEcodeDoc.toDoc(x.value)
+            nelParticleEcodeDoc.toDoc(x.value)
+    )
+
+    implicit val individualEcodeDoc = createEncoder[Entity[Unit, Double]](x =>
+        Doc.paragraph("Entity") + Doc.line +
+            positionEncodeDoc.toDoc(x.pos) + Doc.line
+    )
+
+    implicit val nelIndividualEcodeDoc = createEncoder[NonEmptyList[Entity[Unit, Double]]](x =>
+        Doc.intercalate(Doc.line, x.zipWithIndex.toList map {
+            case (entity: Entity[Unit, Double], index: Int) =>
+                Doc.paragraph(s"Entity ${index + 1}") + Doc.line +
+                    positionEncodeDoc.toDoc(entity.pos) + Doc.line
+        })
+    )
+
+    implicit val progressIndividualEcodeDoc = createEncoder[Progress[NonEmptyList[Entity[Unit, Double]]]](x =>
+        Doc.paragraph(s"Algorithm: ${x.algorithm}") + Doc.line +
+            Doc.paragraph(s"Problem: ${x.problem}") + Doc.line +
+            Doc.paragraph(s"Seed Value: ${x.seed}") + Doc.line +
+            Doc.paragraph(s"Iterations: ${x.iteration}") + Doc.line +
+            Doc.paragraph(s"Environment: ${x.env}") + Doc.line + Doc.line +
+            nelIndividualEcodeDoc.toDoc(x.value)
     )
 
 }

--- a/io/src/main/scala/PrettyPrinter.scala
+++ b/io/src/main/scala/PrettyPrinter.scala
@@ -1,0 +1,32 @@
+package cilib
+package io
+
+import org.typelevel.paiges._
+import scalaz._
+import Scalaz._
+
+object PrettyPrinter {
+
+    implicit class positionPrinterOps(p: Position[Double]){
+        def prettyPrint: Doc = {
+            val pos = Doc.text("Position: ") +
+                Doc.intercalate(Doc.text(", "), p.pos.toList.map(x => Doc.text(x.toString))) +
+                Doc.line
+
+            val bounds = if(p.boundary.toList.forall(_ == p.boundary.head)) {
+                Doc.text("All points in the position share the same bounds of " + p.boundary.head.toString())
+            } else {
+                Doc.text("Bounds: ") +
+                    Doc.intercalate(Doc.text(", "), p.boundary.toList.map(x => Doc.text(x.toString()))) +
+                    Doc.line
+            }
+
+            val solution = Lenses._singleFitness[Double].composePrism(Lenses._feasible).headOption(p) match {
+                    case None        => Doc.empty
+                    case Some(value) => Doc.text("Solution: " + value.toString)
+                }
+
+        }
+    }
+
+}


### PR DESCRIPTION
New functionality to improve the output of examples. An object, `PrettyPrinter` has been added to the `io` package that contains implicit instances of `EncodeDoc` for common types used throughout the `example` package.
Where `EncodeDoc`  is the following 
```scala
sealed trait EncodeDoc[A] {
    def toDoc(x: A): Doc
}
```
And `Doc` is a type from [typelevel/paiges](https://github.com/typelevel/paiges) that allows text to be rendered with a given width size.

Examples that make use of `PrettyPrinter` are 
- GBestPSO
- LBestPSO
- GA

If the design and implementation of the `PrettyPrinter` is correct `PrettyPrinter` functionality can be added to all examples where applicable. 

There is also a public method within `PrettyPrinter` for creating new instances of `EncodeDoc` if users which to use their own types.

Example output below
![image](https://user-images.githubusercontent.com/14876737/45078482-71a3cd00-b0f0-11e8-927b-a10d542ac676.png)
