### PR TITLE
Upgrade avro4s dependency to 3.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,12 +2,12 @@ import sbt._
 import sbt.Keys._
 import sbtrelease.ReleaseStateTransformations._
 
-val scalazVersion     = "7.2.25"
+val scalazVersion       = "7.2.25"
 val scalazStreamVersion = "0.8.6a"
-val spireVersion      = "0.13.0"
-val monocleVersion    = "1.5.0"
-val scalacheckVersion = "1.14.0"
-val avro4sVersion = "1.8.3"
+val spireVersion        = "0.13.0"
+val monocleVersion      = "1.5.0"
+val scalacheckVersion   = "1.14.0"
+val avro4sVersion       = "3.1.0"
 
 // Library requreid for the SBT build itself
 libraryDependencies += "org.scalameta" %% "mdoc" % "2.1.0"

--- a/io/src/main/scala/Avro4sInstances.scala
+++ b/io/src/main/scala/Avro4sInstances.scala
@@ -1,0 +1,41 @@
+package cilib
+package io
+
+import scala.collection.JavaConverters._
+
+import com.sksamuel.avro4s._
+import org.apache.avro.{Schema, SchemaBuilder}
+import org.apache.avro.generic.GenericRecord
+
+import scalaz._
+import Scalaz._
+
+trait Avro4sInstances {
+
+  // NonEmptyList
+  implicit def nonEmptyListEncoder[A](implicit encoder: Encoder[A]) =
+    new Encoder[NonEmptyList[A]] {
+      def encode(ts: NonEmptyList[A], schema: Schema, fieldMapper: FieldMapper): java.util.List[AnyRef] = {
+        require(schema != null)
+        ts.map(encoder.encode(_, schema.getElementType, fieldMapper)).toList.asJava
+      }
+    }
+
+  implicit def nonEmptyListDecoder[T](implicit decoder: Decoder[T]) =
+    new Decoder[NonEmptyList[T]] {
+      override def decode(value: Any, schema: Schema, fieldMapper: FieldMapper): NonEmptyList[T] =
+        value match {
+          case array: Array[_] => array.toList.map(decoder.decode(_, schema, fieldMapper)).toNel.get
+          case list: java.util.Collection[_] =>
+            list.asScala.map(decoder.decode(_, schema, fieldMapper)).toList.toNel.get
+          case other => sys.error("Unsupported type " + other)
+        }
+    }
+
+  implicit def nonEmptyListSchemaFor[T](implicit schemaFor: SchemaFor[T]): SchemaFor[NonEmptyList[T]] =
+    new SchemaFor[NonEmptyList[T]] {
+      def schema(fieldMapper: FieldMapper): Schema =
+        Schema.createArray(schemaFor.schema(fieldMapper))
+    }
+
+}


### PR DESCRIPTION
Upgrade the dependency avro4s and at the same time define how to
encode NonEmptyList instances into parquet files. The NonEmptyList
encoding translates the data structure to a List representation within
the parquet schema.