### PR TITLE
Use `zio-optics` and remove comments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,8 @@ lazy val core = project
   .settings(
     libraryDependencies ++= Seq(
       Dependencies.zio,
-      Dependencies.zioPrelude
+      Dependencies.zioPrelude,
+      Dependencies.zioOptics
     )
   )
   .enablePlugins(BuildInfoPlugin)

--- a/core/src/main/scala/cilib/Constraint.scala
+++ b/core/src/main/scala/cilib/Constraint.scala
@@ -40,8 +40,6 @@ final case class GreaterThanEqual[A](f: ConstraintFunction, v: Double)    extend
 
 object Constraint {
 
-//  def constrain[M[_]](ma: M[Eval[Double]], cs: List[Constraint[Double,Double]])(implicit M: Functor[M]) =
-//    M.map(ma)(_.constrainBy(cs))
   private val ev = zio.prelude.Equal.DoubleEqualWithEpsilon()
 
   def violationMagnitude[A](beta: Double, eta: Double, constraints: List[Constraint], cs: NonEmptyVector[A]): Double =

--- a/core/src/main/scala/cilib/Dist.scala
+++ b/core/src/main/scala/cilib/Dist.scala
@@ -51,36 +51,6 @@ object Dist {
         }
 
       a.repeatUntil { case (zeta, eta) => eta > math.pow(zeta, delta - 1) * math.exp(-zeta) }.map(_._1)
-
-      // a.flatMap(a0 =>
-      //   BindRec[RVar].tailrecM(a0) { (x: (Double, Double)) =>
-      //     val (zeta, eta) = x
-      //     if (eta > math.pow(zeta, delta - 1) * math.exp(-zeta)) a.map(_.left[Double])
-      //     else RVar.pure(zeta.right[(Double, Double)])
-      //   }
-      //)
-
-      // def inner: RVar[Double] =
-      //   for {
-      //     u1 <- stdUniform
-      //     u2 <- stdUniform
-      //     u3 <- stdUniform
-      //     (zeta, eta) = {
-      //       val v0 = math.E / (math.E + delta)
-      //       if (u1 <= v0) {
-      //         val zeta = math.pow(u2, 1.0 / delta)
-      //         val eta = u3 * math.pow(zeta, delta - 1)
-      //         (zeta, eta)
-      //       } else {
-      //         val zeta = 1 - math.log(u2)
-      //         val eta = u3 * math.exp(-zeta)
-      //         (zeta, eta)
-      //       }
-      //     }
-      //     r <- if (eta > math.pow(zeta, delta - 1) * math.exp(-zeta)) inner else RVar.pure(zeta)
-      //   } yield r
-      //
-      // inner
     }
 
     zio.prelude.fx.ZPure.mapN(gammaInt, gammaFrac) { (a, b) =>
@@ -141,7 +111,6 @@ object Dist {
     }
 
     (blocks, blocks.zip(blocks.drop(1)).map(a => a._1 / a._2))
-    //(blocks, ???)//blocks.zip apzip(_.drop(1)).map(a => a._1 / a._2))
   }
 
   def gaussian(mean: Double, dev: Double): RVar[Double] =

--- a/core/src/main/scala/cilib/Fitness.scala
+++ b/core/src/main/scala/cilib/Fitness.scala
@@ -21,6 +21,7 @@ sealed abstract class Fit {
 final case class Feasible(v: Double)                                                              extends Fit
 final case class Infeasible(v: Double)                                                            extends Fit
 final case class Adjusted private[cilib] (original: Either[Feasible, Infeasible], adjust: Double) extends Fit
+
 @annotation.implicitNotFound("No instance of Fitness[${F},${A},${B}] is available in current scope.")
 trait Fitness[F[_], A, B] {
   def fitness(a: F[A]): Option[Objective]

--- a/core/src/main/scala/cilib/Iteration.scala
+++ b/core/src/main/scala/cilib/Iteration.scala
@@ -16,14 +16,7 @@ import zio.prelude._
  *
  * NB: Should consider trying to define this based on the Free monad?
  */
-// sealed trait Iteration[M[_], A] {
-//   def run(l: NonEmptyList[A]): M[List[A]]
-// }
 object Iteration {
-
-  // iterations have the shape: [a] -> a -> Step [a]
-  //def sync_[M[_]:Applicative,A,B:Monoid](f: List[A] => A => M[B]): Kleisli[M,List[A],List[B]] =
-  //Kleisli.kleisli((l: List[A]) => l traverseU f(l))//Functor[M].map(l traverseU f(l))(x => x))
 
   def sync_[M[+_]: Covariant: IdentityBoth, A, B](
     f: NonEmptyVector[A] => A => M[B]

--- a/core/src/main/scala/cilib/Lenses.scala
+++ b/core/src/main/scala/cilib/Lenses.scala
@@ -1,5 +1,8 @@
 package cilib
 
+import zio.optics._
+
+
 final case class Mem[A](b: Position[A], v: Position[A])
 
 @annotation.implicitNotFound("A HasMemory instance cannot be found for the provided state type ${S}")
@@ -13,8 +16,8 @@ object HasMemory {
   implicit val memMemory: HasMemory[Mem[Double], Double] =
     new HasMemory[Mem[Double], Double] {
       def _memory = Lens[Mem[Double], Position[Double]](
-        get = _.b,
-        set = (a, b) => a.copy(b = b)
+        mem => Right(mem.b),
+        pos => mem => Right(mem.copy(b = pos))
       )
     }
 }
@@ -27,8 +30,8 @@ object HasVelocity {
   implicit val memVelocity: HasVelocity[Mem[Double], Double] =
     new HasVelocity[Mem[Double], Double] {
       def _velocity = Lens[Mem[Double], Position[Double]](
-        get = _.v,
-        set = (a, b) => a.copy(v = b)
+        mem => Right(mem.v),
+        vel => mem => Right(mem.copy(v = vel))
       )
     }
 }
@@ -41,18 +44,6 @@ trait HasPBestStagnation[A] {
   def _pbestStagnation: Lens[A, Int]
 }
 
-// Below is a very bare implementation of functional references. This
-// implementation exists because the additional dependencies pulled in
-// by monocle is just too much (i.e. cats is an indirect dependency
-// just for Functor and Applicative)
-
-case class Lens[A, B](
-  get: A => B,
-  set: (A, B) => A
-) {
-  def modify(a: A, f: B => B): A =
-    set(a, f(get(a)))
-}
 
 object Lenses {
   import zio.prelude._
@@ -60,53 +51,19 @@ object Lenses {
   // Base Entity lenses
   def _state[S, A]: Lens[Entity[S, A], S] =
     Lens[Entity[S, A], S](
-      get = _.state,
-      set = (e, c) => e.copy(state = c)
+      entity => Right(entity.state),
+      newState => entity => Right(entity.copy(state = newState))
     )
 
   def _position[S, A]: Lens[Entity[S, A], Position[A]] =
     Lens[Entity[S, A], Position[A]](
-      get = _.pos,
-      set = (e, c) => e.copy(pos = c)
+      entity => Right(entity.pos),
+      newPos => entity => Right(entity.copy(pos = newPos))
     )
 
   def _vector[A: zio.prelude.Equal]: Lens[Position[A], NonEmptyVector[A]] =
     Lens[Position[A], NonEmptyVector[A]](
-      get = _.pos,
-      set = (e, c) => if (e.pos === c) e else Position(c, e.boundary)
+      position => Right(position.pos),
+      newPosition => position => Right(if (position.pos === newPosition) position else Position(newPosition, position.boundary))
     )
-
-  // def _objective[A]: Getter[Position[A], Option[Objective]] =
-  //   Getter(_.objective)
-
-  // def _fitness[A]: Fold[Position[A], Either[Fit, List[Fit]]] =
-  //   _objective[A]
-  //     .composePrism(some[Objective])
-  //     .composeGetter(Getter(_.fitness))
-
-  // def _singleFitness[A]: Fold[Position[A], Fit] =
-  //   _fitness[A].composePrism(left[Fit, List[Fit]])
-
-  // def _multiFitness[A]: Fold[Position[A], List[Fit]] =
-  //   _fitness[A].composePrism(right[Fit, List[Fit]])
-
-  // def _feasible: Prism[Fit, Double] =
-  //   Prism[Fit, Double](_ match {
-  //     case Feasible(x) => Some(x)
-  //     case _           => None
-  //   })(x => Feasible(x))
-
-  // // Helpers that were removed when monocle moved over to cats
-  // final def left[A, B]: Prism[Either[A, B], A] =
-  //   Prism[Either[A, B], A] {
-  //     case Left(a) => Some(a)
-  //     case Right(_) => None
-  //   }(Left.apply)
-
-  // final def right[A, B]: Prism[Either[A, B], B] =
-  //   Prism[Either[A, B], B] {
-  //     case Left(_) => None
-  //     case Right(b) => Some(b)
-  //   }(Right.apply)
-
 }

--- a/core/src/main/scala/cilib/Lenses.scala
+++ b/core/src/main/scala/cilib/Lenses.scala
@@ -2,7 +2,6 @@ package cilib
 
 import zio.optics._
 
-
 final case class Mem[A](b: Position[A], v: Position[A])
 
 @annotation.implicitNotFound("A HasMemory instance cannot be found for the provided state type ${S}")
@@ -44,7 +43,6 @@ trait HasPBestStagnation[A] {
   def _pbestStagnation: Lens[A, Int]
 }
 
-
 object Lenses {
   import zio.prelude._
 
@@ -64,6 +62,7 @@ object Lenses {
   def _vector[A: zio.prelude.Equal]: Lens[Position[A], NonEmptyVector[A]] =
     Lens[Position[A], NonEmptyVector[A]](
       position => Right(position.pos),
-      newPosition => position => Right(if (position.pos === newPosition) position else Position(newPosition, position.boundary))
+      newPosition =>
+        position => Right(if (position.pos === newPosition) position else Position(newPosition, position.boundary))
     )
 }

--- a/core/src/main/scala/cilib/MetricSpace.scala
+++ b/core/src/main/scala/cilib/MetricSpace.scala
@@ -107,13 +107,4 @@ object MetricSpace {
           def dist(x: A, y: A) = B.combine(l.dist(x, y), r.dist(x, y))
         }
     }
-
-  // implicit def metricSpaceMonad[A]: Monad[MetricSpace[A, *]] =
-  //   new Monad[MetricSpace[A, *]] {
-  //     def point[B](a: => B): MetricSpace[A, B] =
-  //       MetricSpace.pure[A, B](a)
-  //
-  //     def bind[B, C](fa: MetricSpace[A, B])(f: B => MetricSpace[A, C]): MetricSpace[A, C] =
-  //       fa.flatMap(f)
-  //   }
 }

--- a/core/src/main/scala/cilib/Step.scala
+++ b/core/src/main/scala/cilib/Step.scala
@@ -36,10 +36,12 @@ object Step {
     } yield a
 
   def eval[S, A](entity: Entity[S, A])(f: Position[A] => Position[A]): Step[Entity[S, A]] =
-    evalP(f(entity.pos)).flatMap(p => Lenses._position.set(p)(entity) match {
-      case Right(value) => Step.pure(value)
-      case Left(reason) => Step.fail(reason, new Exception)
-    })
+    evalP(f(entity.pos)).flatMap(p =>
+      Lenses._position.set(p)(entity) match {
+        case Right(value) => Step.pure(value)
+        case Left(reason) => Step.fail(reason, new Exception)
+      }
+    )
 
   def evalP[A](pos: Position[A]): Step[Position[A]] =
     for {

--- a/core/src/main/scala/cilib/Step.scala
+++ b/core/src/main/scala/cilib/Step.scala
@@ -18,9 +18,6 @@ object Step {
   def fail[A](reason: String, error: Exception): Step[A] =
     zio.prelude.fx.ZPure.fail(new Exception(reason, error))
 
-  // def failString[A, B](reason: String): Step[A, B] =
-  //   Halt(reason, None)
-
   def pure[A](a: A): Step[A] =
     zio.prelude.fx.ZPure.succeed(a)
 
@@ -39,7 +36,10 @@ object Step {
     } yield a
 
   def eval[S, A](entity: Entity[S, A])(f: Position[A] => Position[A]): Step[Entity[S, A]] =
-    evalP(f(entity.pos)).map(p => Lenses._position.set(entity, p))
+    evalP(f(entity.pos)).flatMap(p => Lenses._position.set(p)(entity) match {
+      case Right(value) => Step.pure(value)
+      case Left(reason) => Step.fail(reason, new Exception)
+    })
 
   def evalP[A](pos: Position[A]): Step[Position[A]] =
     for {

--- a/example/src/main/scala/cilib/example/GA.scala
+++ b/example/src/main/scala/cilib/example/GA.scala
@@ -42,7 +42,7 @@ object GAExample extends zio.ZIOAppDefault {
         } yield zb
       }
 
-      newPos.map(p => _position.set(x, p))
+      newPos.map(p => _position.set(p)(x).toOption.get)
     }
 
   val randomSelection: NonEmptyVector[Ind] => RVar[List[Ind]] =

--- a/example/src/main/scala/cilib/example/QuantumPSO.scala
+++ b/example/src/main/scala/cilib/example/QuantumPSO.scala
@@ -1,12 +1,12 @@
 package cilib
 package example
 
+import cilib.NonEmptyVector
 import cilib.exec._
 import cilib.pso._
 import zio._
 import zio.optics._
 import zio.stream._
-import cilib.NonEmptyVector
 
 object QuantumPSO extends zio.ZIOAppDefault {
   import PSO._

--- a/example/src/main/scala/cilib/example/QuantumPSO.scala
+++ b/example/src/main/scala/cilib/example/QuantumPSO.scala
@@ -1,0 +1,118 @@
+package cilib
+package example
+
+import cilib.pso._
+import cilib.exec._
+import zio._
+import zio.stream._
+import zio.optics._
+
+object QuantumPSO extends zio.ZIOAppDefault {
+  import PSO._
+
+  case class QuantumState(b: Position[Double], v: Position[Double], charge: Double)
+
+  type QuantumParticle = Particle[QuantumState, Double]
+
+  object QuantumState {
+    implicit object QSMemory
+        extends HasMemory[QuantumState, Double]
+        with HasVelocity[QuantumState, Double]
+        with HasCharge[QuantumState] {
+      def _memory   = Lens[QuantumState, Position[Double]](
+        state => Right(state.b),
+        newB => state => Right(state.copy(b = newB))
+      )
+      def _velocity = Lens[QuantumState, Position[Double]](
+        state => Right(state.v),
+        newV => state => Right(state.copy(v = newV))
+      )
+      def _charge   = Lens[QuantumState, Double](
+        state => Right(state.charge),
+        newCharge => state => Right(state.copy(charge = newCharge))
+      )
+    }
+  }
+
+  def quantumPSO(
+    w: Double,
+    c1: Double,
+    c2: Double,
+    cognitive: Guide[QuantumState, Double],
+    social: Guide[QuantumState, Double],
+    cloudR: (Position[Double], Position[Double]) => RVar[Double]
+  )(
+    implicit C: HasCharge[QuantumState],
+    V: HasVelocity[QuantumState, Double],
+    M: HasMemory[QuantumState, Double]
+  ): NonEmptyVector[QuantumParticle] => QuantumParticle => Step[QuantumParticle] =
+    collection =>
+      x => {
+        for {
+          cog <- cognitive(collection, x)
+          soc <- social(collection, x)
+          v   <- stdVelocity(x, soc, cog, w, c1, c2)
+          p <- if (C._charge.get(x.state).toOption.get < 0.01) stdPosition(x, v)
+               else quantum(x.pos, cloudR(soc, cog), (_, _) => Dist.stdUniform).flatMap(replace(x, _))
+          p2      <- Step.eval(p)(identity)
+          p3      <- updateVelocity(p2, v)
+          updated <- updatePBestBounds(p3)
+        } yield updated
+      }
+
+  // Usage
+  val domain = Interval(0.0, 100.0) ^ 2
+
+  val qpso: Kleisli[Step, NonEmptyVector[QuantumParticle], NonEmptyVector[QuantumParticle]] =
+    Kleisli(
+      Iteration.sync(
+        quantumPSO(
+          0.729844,
+          1.496180,
+          1.496180,
+          Guide.pbest,
+          Guide.dominance(Selection.star),
+          (_, _) => RVar.pure(50.0)
+        )
+      )
+    )
+
+  def swarm =
+    Position.createCollection(PSO.createParticle(x => Entity(QuantumState(x, x.zeroed, 0.0), x)))(domain, positiveInt(40))
+
+  def pop: RVar[NonEmptyVector[QuantumParticle]] =
+    swarm.map { coll =>
+      val C          = implicitly[HasCharge[QuantumState]]
+      val chargeLens = Lenses._state[QuantumState, Double] >>> C._charge
+
+      coll.zipWithIndex.map {
+        case (current, index) => chargeLens.update(current)(z => if (index % 2 == 1) 0.1 else z).toOption.get
+      }
+    }.flatMap(RVar.shuffle)
+
+  val comparison = Comparison.dominance(Max)
+
+  val problemStream: UStream[Problem] = Runner.staticProblem(
+    "spherical",
+    Eval.unconstrained((x: NonEmptyVector[Double]) => Feasible(ExampleHelper.spherical(x)))
+  )
+  val algStream: UStream[Algorithm[Kleisli[Step, NonEmptyVector[Particle[QuantumState, Double]], NonEmptyVector[Particle[QuantumState, Double]]]]] =
+    Runner.staticAlgorithm("quantumPSO", qpso)
+
+  def run: URIO[Any, ExitCode] = {
+    val t = Runner.foldStep(
+      comparison,
+      RNG.fromTime,
+      pop,
+      algStream,
+      problemStream,
+      (x: NonEmptyVector[Particle[QuantumState, Double]], _: Eval[NonEmptyVector]) => RVar.pure(x)
+    )
+
+    t.take(1000)
+      .runLast
+      .fold(eh => println(eh.toString), ah => println(ah.toString))
+      .exitCode
+  }
+
+}

--- a/example/src/main/scala/cilib/example/QuantumPSO.scala
+++ b/example/src/main/scala/cilib/example/QuantumPSO.scala
@@ -1,11 +1,12 @@
 package cilib
 package example
 
-import cilib.pso._
 import cilib.exec._
+import cilib.pso._
 import zio._
-import zio.stream._
 import zio.optics._
+import zio.stream._
+import cilib.NonEmptyVector
 
 object QuantumPSO extends zio.ZIOAppDefault {
   import PSO._
@@ -19,15 +20,15 @@ object QuantumPSO extends zio.ZIOAppDefault {
         extends HasMemory[QuantumState, Double]
         with HasVelocity[QuantumState, Double]
         with HasCharge[QuantumState] {
-      def _memory   = Lens[QuantumState, Position[Double]](
+      def _memory: Lens[QuantumState, Position[Double]]   = Lens[QuantumState, Position[Double]](
         state => Right(state.b),
         newB => state => Right(state.copy(b = newB))
       )
-      def _velocity = Lens[QuantumState, Position[Double]](
+      def _velocity: Lens[QuantumState, Position[Double]] = Lens[QuantumState, Position[Double]](
         state => Right(state.v),
         newV => state => Right(state.copy(v = newV))
       )
-      def _charge   = Lens[QuantumState, Double](
+      def _charge: Lens[QuantumState, Double]             = Lens[QuantumState, Double](
         state => Right(state.charge),
         newCharge => state => Right(state.copy(charge = newCharge))
       )
@@ -41,27 +42,26 @@ object QuantumPSO extends zio.ZIOAppDefault {
     cognitive: Guide[QuantumState, Double],
     social: Guide[QuantumState, Double],
     cloudR: (Position[Double], Position[Double]) => RVar[Double]
-  )(
-    implicit C: HasCharge[QuantumState],
+  )(implicit
+    C: HasCharge[QuantumState],
     V: HasVelocity[QuantumState, Double],
     M: HasMemory[QuantumState, Double]
   ): NonEmptyVector[QuantumParticle] => QuantumParticle => Step[QuantumParticle] =
     collection =>
-      x => {
+      x =>
         for {
-          cog <- cognitive(collection, x)
-          soc <- social(collection, x)
-          v   <- stdVelocity(x, soc, cog, w, c1, c2)
-          p <- if (C._charge.get(x.state).toOption.get < 0.01) stdPosition(x, v)
-               else quantum(x.pos, cloudR(soc, cog), (_, _) => Dist.stdUniform).flatMap(replace(x, _))
+          cog     <- cognitive(collection, x)
+          soc     <- social(collection, x)
+          v       <- stdVelocity(x, soc, cog, w, c1, c2)
+          p       <- if (C._charge.get(x.state).toOption.get < 0.01) stdPosition(x, v)
+                     else quantum(x.pos, cloudR(soc, cog), (_, _) => Dist.stdUniform).flatMap(replace(x, _))
           p2      <- Step.eval(p)(identity)
           p3      <- updateVelocity(p2, v)
           updated <- updatePBestBounds(p3)
         } yield updated
-      }
 
   // Usage
-  val domain = Interval(0.0, 100.0) ^ 2
+  val domain: NonEmptyVector[Interval] = Interval(0.0, 100.0) ^ 2
 
   val qpso: Kleisli[Step, NonEmptyVector[QuantumParticle], NonEmptyVector[QuantumParticle]] =
     Kleisli(
@@ -77,26 +77,29 @@ object QuantumPSO extends zio.ZIOAppDefault {
       )
     )
 
-  def swarm =
-    Position.createCollection(PSO.createParticle(x => Entity(QuantumState(x, x.zeroed, 0.0), x)))(domain, positiveInt(40))
+  def swarm: cilib.RVar[NonEmptyVector[Particle[QuantumState, Double]]] =
+    Position
+      .createCollection(PSO.createParticle(x => Entity(QuantumState(x, x.zeroed, 0.0), x)))(domain, positiveInt(40))
 
   def pop: RVar[NonEmptyVector[QuantumParticle]] =
     swarm.map { coll =>
       val C          = implicitly[HasCharge[QuantumState]]
       val chargeLens = Lenses._state[QuantumState, Double] >>> C._charge
 
-      coll.zipWithIndex.map {
-        case (current, index) => chargeLens.update(current)(z => if (index % 2 == 1) 0.1 else z).toOption.get
+      coll.zipWithIndex.map { case (current, index) =>
+        chargeLens.update(current)(z => if (index % 2 == 1) 0.1 else z).toOption.get
       }
     }.flatMap(RVar.shuffle)
 
-  val comparison = Comparison.dominance(Max)
+  val comparison: Comparison = Comparison.dominance(Max)
 
   val problemStream: UStream[Problem] = Runner.staticProblem(
     "spherical",
     Eval.unconstrained((x: NonEmptyVector[Double]) => Feasible(ExampleHelper.spherical(x)))
   )
-  val algStream: UStream[Algorithm[Kleisli[Step, NonEmptyVector[Particle[QuantumState, Double]], NonEmptyVector[Particle[QuantumState, Double]]]]] =
+  val algStream: UStream[Algorithm[
+    Kleisli[Step, NonEmptyVector[Particle[QuantumState, Double]], NonEmptyVector[Particle[QuantumState, Double]]]
+  ]]                                  =
     Runner.staticAlgorithm("quantumPSO", qpso)
 
   def run: URIO[Any, ExitCode] = {

--- a/ga/src/main/scala/cilib/ga/GA.scala
+++ b/ga/src/main/scala/cilib/ga/GA.scala
@@ -38,7 +38,7 @@ object GA {
         val newPos: RVar[NonEmptyVector[Double]] = parent.pos.pos.forEach(distribution)
 
         newPos.map { p =>
-          parent.copy(pos = Lenses._vector[Double].set(parent.pos, p))
+          parent.copy(pos = Lenses._vector[Double].set(p)(parent.pos).toOption.get)
         }
       }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,7 @@ object Version {
 
   val zio        = "2.0.0" // matches the zio version used in zio-prelude
   val zioPrelude = "1.0.0-RC15"
+  val zioOptics  = "2.0.0-RC4"
   val parquet4s  = "2.6.0"
 
 }
@@ -13,6 +14,7 @@ object Dependencies {
   val zio          = "dev.zio"                  %% "zio"            % Version.zio
   val zioStreams   = "dev.zio"                  %% "zio-streams"    % Version.zio
   val zioPrelude   = "dev.zio"                  %% "zio-prelude"    % Version.zioPrelude
+  val zioOptics    = "dev.zio"                  %% "zio-optics"     % Version.zioOptics
   val zioTest      = "dev.zio"                  %% "zio-test"       % Version.zio % Test
   val zioTestSbt   = "dev.zio"                  %% "zio-test-sbt"   % Version.zio % Test
   val parquet4s    = "com.github.mjakubowski84" %% "parquet4s-core" % Version.parquet4s

--- a/pso/src/main/scala/cilib/pso/Guide.scala
+++ b/pso/src/main/scala/cilib/pso/Guide.scala
@@ -8,7 +8,7 @@ object Guide {
     (_, x) => Step.pure(x.pos)
 
   def pbest[S, A](implicit M: HasMemory[S, A]): Guide[S, A] =
-    (_, x) => Step.pure(M._memory.get(x.state))
+    (_, x) => Step.pure(M._memory.get(x.state).toOption.get)
 
   def nbest[S](
     neighbourhood: IndexSelection[Particle[S, Double]]
@@ -16,7 +16,7 @@ object Guide {
     Step.withCompare { o =>
       val selected: List[Particle[S, Double]] = neighbourhood(collection, x)
       val fittest                             = selected
-        .map(e => M._memory.get(e.state))
+        .map(e => M._memory.get(e.state).toOption.get)
         .reduceLeftOption((a, c) => Comparison.compare(a, c).apply(o))
       fittest.getOrElse(sys.error("Impossible: reduce on entity memory worked on empty memory member"))
     }


### PR DESCRIPTION
Some much needed cleanup on the code and drop the custom `Lens` implementation in favour of just using the `zio-optics` library.

One caveat of the optics library is that it caters for failures in the lenses, which I've never seen before, and requires that the `OpticResult` be unwrapped in specific places within the code. This is not an issue, but creates slightly more code at the call-sites.